### PR TITLE
Closes #65: Fractional grades on group credits equivalences

### DIFF
--- a/src/main/webapp/WEB-INF/fenix/schemas/academicAdminOffice-schemas.xml
+++ b/src/main/webapp/WEB-INF/fenix/schemas/academicAdminOffice-schemas.xml
@@ -842,10 +842,10 @@
 		<property name="size" value="7"/>
 		<property name="maxLength" value="6"/>
 	</slot>
-	<slot name="grade" layout="grade-input" key="label.studentDismissal.grade" >
-		<property name="maxLength" value="5" />
+	<slot name="grade" layout="grade-input" key="label.studentDismissal.grade" validator="net.sourceforge.fenixedu.presentationTier.renderers.validators.GradeValidator">
+		<property name="size" value="4" />
+		<property name="maxLength" value="2" />
 		<property name="required" value="true" />
-		<property name="size" value="5" />
 	</slot>	
 </schema>
 
@@ -855,10 +855,10 @@
 		<property name="size" value="7"/>
 		<property name="maxLength" value="6"/>
 	</slot>
-	<slot name="grade" layout="grade-input" key="label.studentDismissal.grade" >
-		<property name="maxLength" value="5" />
+	<slot name="grade" layout="grade-input" key="label.studentDismissal.grade" validator="net.sourceforge.fenixedu.presentationTier.renderers.validators.GradeValidator">
+		<property name="size" value="4" />
+		<property name="maxLength" value="2" />
 		<property name="required" value="true" />
-		<property name="size" value="5" />
 	</slot>	
 </schema>
 


### PR DESCRIPTION
Added grade validation to the academic office schema grade slots that correspond to the group credits equivalence assignments.

It is still necessary to correct the fractional grades already submitted into the system to close the RT ticket properly.
