### PR TITLE
Fixes #97. NullPointerException on Registration.getDescription()

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/domain/student/Registration.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/student/Registration.java
@@ -2773,7 +2773,7 @@ public class Registration extends Registration_Base {
     }
 
     private boolean isEmptyDegree() {
-        return getLastDegreeCurricularPlan().isEmpty();
+        return (getLastStudentCurricularPlan() != null ? getLastStudentCurricularPlan().isEmpty() : true);
     }
 
     final public CycleType getLastConcludedCycleType() {


### PR DESCRIPTION
If there isn't a curricular plan than the degree is automatically empty.
