### PR TITLE
Fixes #104. Past Delegates Emails

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/delegate/SendEmailToDelegateStudents.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/delegate/SendEmailToDelegateStudents.java
@@ -139,14 +139,13 @@ public class SendEmailToDelegateStudents extends FenixDispatchAction {
             for (Registration registration : activeRegistrations) {
                 delegateFunction = registration.getDegree().getMostSignificantDelegateFunctionForStudent(student, executionYear);
                 if (delegateFunction != null && delegateFunction.isActive()) {
-                    break;
+                    return delegateFunction;
                 }
-                delegateFunction = null;
             }
         } else {
-            delegateFunction = person.getActiveGGAEDelegatePersonFunction();
+            return person.getActiveGGAEDelegatePersonFunction();
         }
-        return delegateFunction;
+        return null; // no active function was found
     }
 
     public ActionForward prepareSendToStudentsFromSelectedCurricularCourses(ActionMapping mapping, ActionForm actionForm,


### PR DESCRIPTION
It was needed to see if the delegate was still active. The change from active to inactive happens when a new delegate is elected
