### PR TITLE
Closes #107:footer invariably presents the institution's name

### DIFF
--- a/src/main/webapp/publico/homepage/footer.jsp
+++ b/src/main/webapp/publico/homepage/footer.jsp
@@ -13,13 +13,7 @@
 <div id="foot_copy">
 	<bean:message bundle="GLOBAL_RESOURCES" key="footer.copyright.label"/>
 	<dt:format pattern="yyyy"><dt:currentTime/></dt:format>
-	-
-	<logic:present name="homepage">
-		<bean:write name="homepage" property="person.name"/>
-	</logic:present>
-	<logic:notPresent name="homepage">
-		<%=net.sourceforge.fenixedu.domain.organizationalStructure.Unit.getInstitutionName()%>
-	</logic:notPresent>
+	- <%=net.sourceforge.fenixedu.domain.organizationalStructure.Unit.getInstitutionName()%>
 </div>
 
 <div class="clear"></div>


### PR DESCRIPTION
Removed the person's name from his public page footer. Now the footer invariably presents the institution's name.
