### PR TITLE
Closes Ticket 380361: Fix/admin photo extra functionalities

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/manager/photographs/PhotographHistoryDA.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/manager/photographs/PhotographHistoryDA.java
@@ -13,8 +13,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import net.sourceforge.fenixedu.dataTransferObject.photographs.PhotographFilterBean;
 import net.sourceforge.fenixedu.domain.Person;
-import net.sourceforge.fenixedu.domain.PhotoState;
-import net.sourceforge.fenixedu.domain.PhotoType;
 import net.sourceforge.fenixedu.domain.Photograph;
 import net.sourceforge.fenixedu.presentationTier.Action.base.FenixDispatchAction;
 
@@ -31,8 +29,7 @@ import pt.ist.fenixWebFramework.struts.annotations.Mapping;
  * @author Pedro Santos (pmrsa)
  */
 @Mapping(path = "/photographs/history", module = "manager")
-@Forwards({ @Forward(name = "history", path = "/manager/photographs/photographHistory.jsp"),
-        @Forward(name = "listByState", path = "/manager/photographs/listByState.jsp") })
+@Forwards({ @Forward(name = "history", path = "/manager/photographs/photographHistory.jsp") })
 public class PhotographHistoryDA extends FenixDispatchAction {
     public class DatedRejections {
         private final DateTime date;
@@ -107,40 +104,4 @@ public class PhotographHistoryDA extends FenixDispatchAction {
         return mapping.findForward("history");
     }
 
-    public ActionForward rejections(ActionMapping mapping, ActionForm actionForm, HttpServletRequest request,
-            HttpServletResponse response) throws Exception {
-        SortedMap<DateTime, DatedRejections> rejections = getSortedPhotographsByState(PhotoState.REJECTED);
-        request.setAttribute("photographs", rejections.values());
-        return mapping.findForward("listByState");
-    }
-
-    public ActionForward approvals(ActionMapping mapping, ActionForm actionForm, HttpServletRequest request,
-            HttpServletResponse response) throws Exception {
-        SortedMap<DateTime, DatedRejections> approvals = getSortedPhotographsByState(PhotoState.APPROVED);
-        request.setAttribute("photographs", approvals.values());
-        return mapping.findForward("listByState");
-    }
-
-    private SortedMap<DateTime, DatedRejections> getSortedPhotographsByState(PhotoState state) {
-        Set<Photograph> photos = rootDomainObject.getPhotographsSet();
-
-        SortedMap<DateTime, DatedRejections> rejections = new TreeMap<DateTime, DatedRejections>();
-        for (Photograph photograph : photos) {
-            if (photograph.getState() == state && photograph.getPhotoType() == PhotoType.USER) {
-                DateTime date = stripHours(photograph.getStateChange());
-                if (rejections.containsKey(date)) {
-                    rejections.get(date).addPhotograph(photograph);
-                } else {
-                    DatedRejections datedRejection = new DatedRejections(date);
-                    datedRejection.addPhotograph(photograph);
-                    rejections.put(date, datedRejection);
-                }
-            }
-        }
-        return rejections;
-    }
-
-    private static DateTime stripHours(DateTime date) {
-        return new DateTime(date.toDateMidnight());
-    }
 }


### PR DESCRIPTION
Removed the useless and bugged admin photo filters. Their corresponding links in the admin's lateral navigation bar ('Aprovacoes' and 'Rejeicoes', inserted in /fenix/etc/database_operations/R2008/R2008-10-03/photoHistoryPortal.sql I think) still have to be removed.
