### PR TITLE
Closes #229: Added missing JSP logic

### DIFF
--- a/src/main/webapp/debugExceptionPage.jsp
+++ b/src/main/webapp/debugExceptionPage.jsp
@@ -77,13 +77,17 @@
 								-->.<!--
 								--><span class="methodName"><bean:write name="debugExceptionInfo" property="actionErrorMethod"/></span><!--
 							--></span><!--
+							--><logic:present name="debugExceptionInfo" property="actionErrorFile"><!--
 							-->(<!--
 							--><span class="fileLocation"><!--
 								--><span class="fileName"><bean:write name="debugExceptionInfo" property="actionErrorFile"/></span><!--
+								--><logic:present name="debugExceptionInfo" property="actionErrorLine"><!--
 								-->:<!--
 								--><span class="lineNumber"><bean:write name="debugExceptionInfo" property="actionErrorLine"/></span><!--
+								--></logic:present><!-- 
 							--></span><!--
 							-->)<!--
+							--></logic:present>
 						--></span><!--
 					--></span><!--
 				--></logic:present>


### PR DESCRIPTION
Now when we are unable to detect the file associated with the method where the exception occurs we do not display the parentheses. Also if we can't find the line it does not present :0.
