### PR TITLE
Closes #229: Added missing JSP logic

### DIFF
--- a/src/main/webapp/debugExceptionPage.jsp
+++ b/src/main/webapp/debugExceptionPage.jsp
@@ -84,7 +84,7 @@
 								--><logic:notEqual name="debugExceptionInfo" property="actionErrorLine" value="0"><!--
 								-->:<!--
 								--><span class="lineNumber"><bean:write name="debugExceptionInfo" property="actionErrorLine"/></span><!--
-								--></logic:notEqual><!-- 
+								--></logic:notEqual><!--
 							--></span><!--
 							-->)<!--
 							--></logic:present>


### PR DESCRIPTION
 Now when we are unable to detect the file associated with the method where the exception occurs we do not display the parentheses. Also if we can't find the line it does not present :0.

ps: the extra commits resulted from a blunder with git
