### PR TITLE
Search for persons with no user assigned

### DIFF
--- a/src/main/webapp/manager/personManagement/contracts/showProfessionalInformation.jsp
+++ b/src/main/webapp/manager/personManagement/contracts/showProfessionalInformation.jsp
@@ -7,6 +7,7 @@
 
 <html:xhtml/>
 <logic:present name="person">
+
 	<em><bean:message key="label.person.main.title" bundle="APPLICATION_RESOURCES"/></em>
 	<h2><bean:message key="link.title.professionalInformation" bundle="CONTRACTS_RESOURCES"/></h2>
 	<div class="infoselected">
@@ -14,13 +15,15 @@
 		<table>
 			<tr>
 				<th scope="row"><bean:message key="label.person.username" bundle="APPLICATION_RESOURCES"/></th>
-				<td><bean:write name="person" property="user.username"/></td>
-				<logic:present name="person" property="employee">
-					<td>, <bean:write name="person" property="employee.employeeNumber"/></td>
-				</logic:present>
-				<logic:present name="person" property="student">
-					<td>, <bean:write name="person" property="student.number"/></td>
-				</logic:present>
+				<logic:notEmpty name="person" property="user">
+					<td><bean:write name="person" property="user.username"/></td>
+				</logic:notEmpty>
+				<logic:notEmpty name="person" property="student">
+					<td><bean:write name="person" property="student.number"/></td>
+				</logic:notEmpty>
+				<logic:notEmpty name="person" property="employee">
+					<td><bean:write name="person" property="employee.employeeNumber"/></td>
+				</logic:notEmpty>
 			</tr>
 		</table>
 	</div>

--- a/src/main/webapp/manager/personManagement/displayPerson.jsp
+++ b/src/main/webapp/manager/personManagement/displayPerson.jsp
@@ -1,3 +1,8 @@
+<%@page import="org.apache.commons.lang.StringUtils"%>
+<%@page import="com.google.common.base.Joiner"%>
+<%@page import="net.sourceforge.fenixedu.domain.Employee"%>
+<%@page import="net.sourceforge.fenixedu.domain.student.Student"%>
+<%@page import="org.fenixedu.bennu.core.domain.User"%>
 <%@page import="net.sourceforge.fenixedu.util.FenixConfigurationManager"%>
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
@@ -77,15 +82,22 @@ function check(e,v){
 	<cp:collectionPages url="<%= url %>" numberOfVisualizedPages="11" pageNumberAttributeName="pageNumber" numberOfPagesAttributeName="numberOfPages"/>			
 	<br /><br />
 		
-	<logic:iterate id="personalInfo" name="personListFinded" indexId="personIndex">	   
+	<logic:iterate id="personalInfo" name="personListFinded" indexId="personIndex" type="net.sourceforge.fenixedu.domain.Person">	   
 		<bean:define id="personID" name="personalInfo" property="externalId"/>
+		<% 
+			String username = personalInfo.getUser() !=null ? personalInfo.getUser().getUsername() : null;
+			Integer studentNumber = personalInfo.getStudent() != null ? personalInfo.getStudent().getNumber() : null;
+			Integer employeeNumber = personalInfo.getEmployee() != null ? personalInfo.getEmployee().getEmployeeNumber() : null;
+			String personalIds = Joiner.on(", ").skipNulls().join(username, studentNumber, employeeNumber);
+			personalIds = StringUtils.isNotBlank(personalIds) ? "(" + personalIds + ")" : "";
+		%>
 		<div class="pp">
 			<table class="ppid" cellpadding="0" cellspacing="0">
 				<tr>
 					<td width="70%">
 						<strong>
 						 	<html:link action="<%= "/findPerson.do?method=viewPerson&personID="+personID %>" > <bean:write name="personalInfo" property="name"/> </html:link>					
-						</strong> (<bean:write name="personalInfo" property="user.username"/><logic:present name="personalInfo" property="employee">, <bean:write name="personalInfo" property="employee.employeeNumber"/></logic:present><logic:present name="personalInfo" property="student">, <bean:write name="personalInfo" property="student.number"/></logic:present>)
+						</strong> <%= personalIds %>
 						<bean:size id="mainRolesSize" name="personalInfo" property="mainRoles"></bean:size> 
 						<logic:greaterThan name="mainRolesSize" value="0">
 							<logic:iterate id="role" name="personalInfo" property="mainRoles" indexId="i">

--- a/src/main/webapp/person/findPerson/findPerson.jsp
+++ b/src/main/webapp/person/findPerson/findPerson.jsp
@@ -1,3 +1,9 @@
+<%@page import="org.apache.commons.lang.StringUtils"%>
+<%@page import="com.google.common.base.Strings"%>
+<%@page import="com.google.common.base.Joiner"%>
+<%@page import="org.fenixedu.bennu.core.domain.User"%>
+<%@page import="net.sourceforge.fenixedu.domain.Employee"%>
+<%@page import="net.sourceforge.fenixedu.domain.student.Student"%>
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html"%>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
@@ -164,15 +170,20 @@ function check(e,v){
 	</p>
 
 	<logic:iterate id="personalInfo" name="personListFinded"
-		indexId="personIndex">
+		indexId="personIndex" type="net.sourceforge.fenixedu.domain.Person">
 		<bean:define id="personID" name="personalInfo" property="externalId" />
-
+		<% 
+			String username = personalInfo.getUser() !=null ? personalInfo.getUser().getUsername() : null;
+			Integer studentNumber = personalInfo.getStudent() != null ? personalInfo.getStudent().getNumber() : null;
+			Integer employeeNumber = personalInfo.getEmployee() != null ? personalInfo.getEmployee().getEmployeeNumber() : null;
+			String personalIds = Joiner.on(", ").skipNulls().join(username, studentNumber, employeeNumber);
+			personalIds = StringUtils.isNotBlank(personalIds) ? "(" + personalIds + ")" : "";
+		%>
 		<div class="pp">
 			<table class="ppid" cellpadding="0" cellspacing="0">
 				<tr>
-					<td width="70%"><strong> <bean:write
-								name="personalInfo" property="name" /> </strong> (<bean:write name="personalInfo" property="user.username"/><logic:present name="personalInfo" property="employee">, <bean:write name="personalInfo" property="employee.employeeNumber"/></logic:present><logic:present name="personalInfo" property="student">, <bean:write name="personalInfo" property="student.number"/></logic:present>) <bean:size
-							id="mainRolesSize" name="personalInfo" property="mainRoles"></bean:size>
+					<td width="70%"><strong> <bean:write name="personalInfo" property="name" /> </strong> <%= personalIds %>
+					<bean:size	id="mainRolesSize" name="personalInfo" property="mainRoles"></bean:size>
 						<logic:greaterThan name="mainRolesSize" value="0">
 							<logic:iterate id="role" name="personalInfo" property="mainRoles"
 								indexId="i">


### PR DESCRIPTION
Closes #298.

When a search was made and the results contai some user that has no user assigned the search result was not shown.

We now verify if the user is null before trying to read his username.

As all the ids of a user can be null, the way in which they are present (separated by comma) would have been more complex to implement (lots of IFs). I've refactored the code so that we can use the Guava Joiner to join all the user ids.
