### PR TITLE
Unordered queue jobs

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/domain/QueueJob.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/QueueJob.java
@@ -1,5 +1,7 @@
 package net.sourceforge.fenixedu.domain;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import net.sourceforge.fenixedu.injectionCode.AccessControl;
@@ -16,6 +18,13 @@ public abstract class QueueJob extends QueueJob_Base {
     public static enum Priority {
         HIGH, NORMAL;
     }
+
+    static final public Comparator<QueueJob> COMPARATORY_BY_REQUEST_DATE = new Comparator<QueueJob>() {
+        @Override
+        public int compare(QueueJob o1, QueueJob o2) {
+            return o2.getRequestDate().compareTo(o1.getRequestDate());
+        }
+    };
 
     public QueueJob() {
         super();
@@ -45,9 +54,15 @@ public abstract class QueueJob extends QueueJob_Base {
         return !getDone() && hasBennuQueueUndone();
     }
 
-    public static List<QueueJob> getAllJobsForClassOrSubClass(final Class<? extends QueueJob> type, int maxSize) {
-        List<QueueJob> tempList = Lists.newArrayList(Iterables.filter(Bennu.getInstance().getQueueJobSet(), type));
-        return tempList.size() > maxSize ? tempList.subList(0, maxSize) : tempList;
+    public static List<QueueJob> getLastJobsForClassOrSubClass(final Class<? extends QueueJob> type, int maxSize) {
+        return getAllJobsForClassOrSubClass(type, maxSize, COMPARATORY_BY_REQUEST_DATE);
+    }
+
+    public static List<QueueJob> getAllJobsForClassOrSubClass(final Class<? extends QueueJob> type, int maxSize,
+            Comparator<QueueJob> comparator) {
+        List<QueueJob> jobs = Lists.newArrayList(Iterables.filter(Bennu.getInstance().getQueueJobSet(), type));
+        Collections.sort(jobs, comparator);
+        return jobs.size() > maxSize ? jobs.subList(0, maxSize) : jobs;
     }
 
     public static List<QueueJob> getUndoneJobsForClass(final Class<? extends QueueJob> type) {

--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/gep/ReportsByDegreeTypeDA.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/gep/ReportsByDegreeTypeDA.java
@@ -109,7 +109,7 @@ public class ReportsByDegreeTypeDA extends FenixDispatchAction {
     }
 
     public List<QueueJob> getLatestJobs() {
-        return QueueJob.getAllJobsForClassOrSubClass(GepReportFile.class, 5);
+        return QueueJob.getLastJobsForClassOrSubClass(GepReportFile.class, 5);
     }
 
     @SuppressWarnings("unused")
@@ -205,7 +205,7 @@ public class ReportsByDegreeTypeDA extends FenixDispatchAction {
         final ExecutionYear executionYear = getExecutionYear(request);
         request.setAttribute("executionYearID", (executionYear == null) ? null : executionYear.getExternalId());
         final String fileType = getFileType(request);
-        for (QueueJob queueJob : QueueJob.getAllJobsForClassOrSubClass(GepReportFile.class, 5)) {
+        for (QueueJob queueJob : getLatestJobs()) {
             GepReportFile gepReportFile = (GepReportFile) queueJob;
             if ((gepReportFile.getPerson() == person) && (gepReportFile.getClass() == aClass) && (!gepReportFile.getDone())
                     && (gepReportFile.getExecutionYear() == executionYear) && (gepReportFile.getDegreeType() == degreeType)

--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/pedagogicalCouncil/highPerformance/StudentHighPerformance.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/pedagogicalCouncil/highPerformance/StudentHighPerformance.java
@@ -22,7 +22,7 @@ import pt.ist.fenixWebFramework.struts.annotations.Mapping;
 public class StudentHighPerformance extends FenixDispatchAction {
     public ActionForward listRequests(ActionMapping mapping, ActionForm actionForm, HttpServletRequest request,
             HttpServletResponse response) throws Exception {
-        List<QueueJob> jobs = QueueJob.getAllJobsForClassOrSubClass(StudentHighPerformanceQueueJob.class, 5);
+        List<QueueJob> jobs = QueueJob.getLastJobsForClassOrSubClass(StudentHighPerformanceQueueJob.class, 5);
         request.setAttribute("jobs", jobs);
         return mapping.findForward("listRequests");
     }

--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/pedagogicalCouncil/studentLowPerformance/StudentLowPerformanceDA.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/pedagogicalCouncil/studentLowPerformance/StudentLowPerformanceDA.java
@@ -74,7 +74,7 @@ public class StudentLowPerformanceDA extends FenixDispatchAction {
     }
 
     public List<QueueJob> getLatestJobs() {
-        return (QueueJob.getAllJobsForClassOrSubClass(TutorshipStudentLowPerformanceQueueJob.class, 5));
+        return QueueJob.getLastJobsForClassOrSubClass(TutorshipStudentLowPerformanceQueueJob.class, 5);
     }
 
     private ActionForward viewJobs(ActionMapping mapping, ActionForm actionForm, HttpServletRequest request,

--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/publicRelationsOffice/StudentReportsDA.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/publicRelationsOffice/StudentReportsDA.java
@@ -29,7 +29,7 @@ import pt.ist.fenixframework.FenixFramework;
 public class StudentReportsDA extends FenixDispatchAction {
 
     public List<QueueJob> getLatestJobs() {
-        return QueueJob.getAllJobsForClassOrSubClass(PublicRelationsStudentListQueueJob.class, 5);
+        return QueueJob.getLastJobsForClassOrSubClass(PublicRelationsStudentListQueueJob.class, 5);
     }
 
     public ActionForward search(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response)
@@ -49,9 +49,7 @@ public class StudentReportsDA extends FenixDispatchAction {
             }
         }
 
-        List<QueueJob> queueJobList = getLatestJobs();
-
-        request.setAttribute("queueJobList", queueJobList);
+        request.setAttribute("queueJobList", getLatestJobs());
         request.setAttribute("studentReportPredicate", studentReportPredicate);
         return mapping.findForward("search");
     }


### PR DESCRIPTION
Closes #280

Minor Refactor on the way the Queue Jobs where being filtered;

Added a method that knows how to filter and get the last jobs (ordered by creation date);

Using this method where it was previously assumed that the queue jobs were ordered.
