### PR TITLE
When the execution Course is deleted it removes all the recipients from ...

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/domain/ExecutionCourse.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/ExecutionCourse.java
@@ -482,6 +482,7 @@ public class ExecutionCourse extends ExecutionCourse_Base {
         if (canBeDeleted()) {
 
             if (hasSender()) {
+                getSender().getRecipientsSet().clear();
                 setSender(null);
             }
 


### PR DESCRIPTION
Closes #303

When the ExecutionCourse is removed it disconects his Sender, however, the Sender has 3 fixed Recipients that have references to the ExecutionCourse and they were not being removed.

With this update when we delete an ExecutionCourse it disconnects with the Sender and removes all its recipients.
