### PR TITLE
Fix the Final Clearance warning rule.

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/dataTransferObject/student/RegistrationConclusionBean.java
+++ b/src/main/java/net/sourceforge/fenixedu/dataTransferObject/student/RegistrationConclusionBean.java
@@ -230,7 +230,7 @@ public class RegistrationConclusionBean implements Serializable, IRegistrationBe
     public Collection<CurriculumGroup> getCurriculumGroupsNotVerifyingStructure() {
         if (isByCycle()) {
             final Collection<CurriculumGroup> result = new HashSet<CurriculumGroup>();
-            getCycleCurriculumGroup().assertCorrectStructure(result);
+            getCycleCurriculumGroup().assertCorrectStructure(result, getConclusionYear());
             return result;
         } else {
             return Collections.emptyList();

--- a/src/main/java/net/sourceforge/fenixedu/domain/studentCurriculum/CurriculumGroup.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/studentCurriculum/CurriculumGroup.java
@@ -841,18 +841,18 @@ public class CurriculumGroup extends CurriculumGroup_Base {
         }
     }
 
-    public void assertCorrectStructure(final Collection<CurriculumGroup> result) {
+    public void assertCorrectStructure(final Collection<CurriculumGroup> result, ExecutionYear lastApprovedYear) {
         for (final CurriculumGroup curriculumGroup : getCurriculumGroups()) {
-            if (curriculumGroup.getCurriculumGroups().isEmpty() && curriculumGroup.hasUnexpectedCredits()) {
+            if (curriculumGroup.getCurriculumGroups().isEmpty() && curriculumGroup.hasUnexpectedCredits(lastApprovedYear)) {
                 result.add(curriculumGroup);
             } else {
-                curriculumGroup.assertCorrectStructure(result);
+                curriculumGroup.assertCorrectStructure(result, lastApprovedYear);
             }
         }
     }
 
-    public boolean hasUnexpectedCredits() {
-        return getAprovedEctsCredits().doubleValue() != getCreditsConcluded().doubleValue();
+    public boolean hasUnexpectedCredits(ExecutionYear lastApprovedYear) {
+        return getAprovedEctsCredits().doubleValue() != getCreditsConcluded(lastApprovedYear).doubleValue();
     }
 
     public boolean hasInsufficientCredits() {


### PR DESCRIPTION
When doing the Final Clearance, the last approved execution year of cycle is now used to get the correct rule to apply to each group of student's curriculum.
closes #358
