### PR TITLE
Fixing ordering bug on sections and items

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/domain/Item.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/Item.java
@@ -18,9 +18,13 @@
  */
 package net.sourceforge.fenixedu.domain;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import net.sourceforge.fenixedu.domain.cms.CmsContent;
 import net.sourceforge.fenixedu.domain.exceptions.DuplicatedNameException;
 import pt.utl.ist.fenix.tools.util.i18n.MultiLanguageString;
 
@@ -83,13 +87,21 @@ public class Item extends Item_Base {
     }
 
     public void setNextItem(Item item) {
+        List<CmsContent> ordered = getOrderedNeighboors();
+
+        ordered.remove(this);
+
         if (item != null) {
-            Integer order = item.getOrder();
-            shiftRight(getParent().getChildSet(), order);
-            setOrder(order);
+            ordered.add(ordered.indexOf(item), this);
         } else {
-            setOrder(getParent().getChildSet().size());
+            ordered.add(this);
         }
+
+        IntStream.range(0, ordered.size()).forEach(i -> ordered.get(i).setOrder(i));
+    }
+
+    private ArrayList<CmsContent> getOrderedNeighboors() {
+        return getParent().getChildSet().stream().sorted().collect(Collectors.toCollection(ArrayList::new));
     }
 
     /**

--- a/src/main/java/net/sourceforge/fenixedu/domain/Section.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/Section.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import net.sourceforge.fenixedu.domain.cms.CmsContent;
 import net.sourceforge.fenixedu.domain.cms.TemplatedSectionInstance;
@@ -106,15 +108,24 @@ public class Section extends Section_Base {
     }
 
     public void setNextSection(Section section) {
+        List<CmsContent> ordered = getOrderedSiblings();
+
+        ordered.remove(this);
+
         if (section != null) {
-            Integer order = section.getOrder();
-            shiftRight(getSiblings(), section.getOrder());
-            setOrder(order);
+            ordered.add(ordered.indexOf(section), this);
         } else {
-            setOrder(getSiblings().size());
+            ordered.add(this);
         }
+
+        IntStream.range(0, ordered.size()).forEach(i -> ordered.get(i).setOrder(i));
     }
 
+
+    private ArrayList<CmsContent> getOrderedSiblings() {
+        return getSiblings().stream().sorted().collect(Collectors.toCollection(ArrayList::new));
+    }
+    
     private Collection<? extends CmsContent> getSiblings() {
         return getSite() != null ? getSite().getAssociatedSectionSet() : getParent().getChildSet();
     }

--- a/src/main/java/net/sourceforge/fenixedu/domain/cms/CmsContent.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/cms/CmsContent.java
@@ -186,12 +186,4 @@ public class CmsContent extends CmsContent_Base implements Comparable<CmsContent
         }
     }
 
-    public void shiftRight(Collection<? extends CmsContent> contents, Integer order) {
-        for (CmsContent content : contents) {
-            if (content.getOrder() >= order) {
-                content.setOrder(content.getOrder() + 1);
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
When we insert an item/section at the end, they stay with the same order value

and from then on the order is decided by other parameters, not producing the desired functionality.

we now use a list order to implement this functionality.

Closes #491
