### PR TITLE
fix rt#417955 - Cut Abstract in thesis identification document

### DIFF
--- a/src/main/jasperreports/thesis/newStudentIdentification.jrxml
+++ b/src/main/jasperreports/thesis/newStudentIdentification.jrxml
@@ -168,6 +168,9 @@
 				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
 				<subreportExpression class="java.lang.String"><![CDATA["reports/thesis/thesisReport_keywords.jasper"]]></subreportExpression>
 			</subreport>
+			<break type="Page">
+				<reportElement x="0" y="91"	width="425"	height="0"/>
+			</break>
 			<textField isBlankWhenNull="false">
 				<reportElement key="abstractPt-title" positionType="Float" x="0" y="92" width="425" height="17"/>
 				<box>


### PR DESCRIPTION
Added a Page break to thesis identification document to prevent the abstract from being cut between pages.
