### PR TITLE
External candidacies

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/domain/candidacyProcess/erasmus/ErasmusVacancyBean.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/candidacyProcess/erasmus/ErasmusVacancyBean.java
@@ -18,6 +18,8 @@
  */
 package net.sourceforge.fenixedu.domain.candidacyProcess.erasmus;
 
+import java.util.List;
+
 import net.sourceforge.fenixedu.domain.Country;
 import net.sourceforge.fenixedu.domain.Degree;
 import net.sourceforge.fenixedu.domain.candidacyProcess.mobility.MobilityAgreement;
@@ -31,7 +33,7 @@ public class ErasmusVacancyBean implements java.io.Serializable {
 
     private UniversityUnit university;
     private Country country;
-    private Degree degree;
+    private List<Degree> degrees;
 
     private Integer numberOfVacancies;
 
@@ -68,12 +70,12 @@ public class ErasmusVacancyBean implements java.io.Serializable {
         this.country = country;
     }
 
-    public Degree getDegree() {
-        return degree;
+    public List<Degree> getDegrees() {
+        return degrees;
     }
 
-    public void setDegree(Degree degree) {
-        this.degree = degree;
+    public void setDegrees(List<Degree> degrees) {
+        this.degrees = degrees;
     }
 
     public Integer getNumberOfVacancies() {

--- a/src/main/java/net/sourceforge/fenixedu/domain/candidacyProcess/mobility/MobilityApplicationProcess.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/candidacyProcess/mobility/MobilityApplicationProcess.java
@@ -546,8 +546,10 @@ public class MobilityApplicationProcess extends MobilityApplicationProcess_Base 
         protected MobilityApplicationProcess executeActivity(MobilityApplicationProcess process, User userView, Object object) {
             ErasmusVacancyBean bean = (ErasmusVacancyBean) object;
 
-            MobilityQuota.createVacancy(process.getCandidacyPeriod(), bean.getDegree(), bean.getMobilityProgram(),
-                    bean.getUniversity(), bean.getNumberOfVacancies());
+            for (Degree degree : bean.getDegrees()) {
+                MobilityQuota.createVacancy(process.getCandidacyPeriod(), degree, bean.getMobilityProgram(),
+                        bean.getUniversity(), bean.getNumberOfVacancies());
+            }
 
             return process;
         }

--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/candidacy/erasmus/ErasmusCandidacyProcessDA.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/candidacy/erasmus/ErasmusCandidacyProcessDA.java
@@ -352,7 +352,7 @@ public class ErasmusCandidacyProcessDA extends CandidacyProcessDA {
         public Object provide(Object source, Object currentValue) {
             final List<Degree> degrees =
                     new ArrayList<Degree>(Degree.readAllByDegreeType(DegreeType.BOLONHA_INTEGRATED_MASTER_DEGREE,
-                            DegreeType.BOLONHA_MASTER_DEGREE, DegreeType.BOLONHA_DEGREE));
+                            DegreeType.BOLONHA_MASTER_DEGREE));
 
             degrees.remove(Degree.readBySigla("MSCIT"));
 
@@ -363,7 +363,7 @@ public class ErasmusCandidacyProcessDA extends CandidacyProcessDA {
 
         @Override
         public Converter getConverter() {
-            return new DomainObjectKeyConverter();
+            return null;
         }
 
     }

--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/candidacy/erasmus/ErasmusIndividualCandidacyProcessDA.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/candidacy/erasmus/ErasmusIndividualCandidacyProcessDA.java
@@ -168,6 +168,15 @@ public class ErasmusIndividualCandidacyProcessDA extends IndividualCandidacyProc
         return mapping.findForward("fill-degree-information");
     }
 
+    public ActionForward chooseMobilityProgram(ActionMapping mapping, ActionForm form, HttpServletRequest request,
+            HttpServletResponse response) {
+        request.setAttribute(getIndividualCandidacyProcessBeanName(), readIndividualCandidacyProcessBean(request));
+        request.setAttribute("degreeCourseInformationBean", readDegreeCourseInformationBean(request));
+        request.setAttribute("mobilityIndividualApplicationProcessBean", readMobilityDegreeInformation(request));
+        RenderUtils.invalidateViewState();
+        return mapping.findForward("edit-degree-courses-information");
+    }
+
     public ActionForward chooseDegreeForMobility(ActionMapping mapping, ActionForm form, HttpServletRequest request,
             HttpServletResponse response) {
         request.setAttribute(getIndividualCandidacyProcessBeanName(), getIndividualCandidacyProcessBean());
@@ -191,6 +200,10 @@ public class ErasmusIndividualCandidacyProcessDA extends IndividualCandidacyProc
 
     private MobilityIndividualApplicationProcessBean readMobilityDegreeInformation(HttpServletRequest request) {
         return getRenderedObject("mobility.individual.application");
+    }
+
+    private MobilityIndividualApplicationProcessBean readIndividualCandidacyProcessBean(HttpServletRequest request) {
+        return getRenderedObject("individualCandidacyProcessBean");
     }
 
     public ActionForward addCourse(ActionMapping mapping, ActionForm form, HttpServletRequest request,

--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/candidacy/erasmus/MobilityProgramProvider.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/candidacy/erasmus/MobilityProgramProvider.java
@@ -23,7 +23,6 @@ import java.util.TreeSet;
 
 import net.sourceforge.fenixedu.domain.candidacyProcess.mobility.MobilityAgreement;
 import net.sourceforge.fenixedu.domain.candidacyProcess.mobility.MobilityProgram;
-import net.sourceforge.fenixedu.domain.candidacyProcess.mobility.MobilityStudentDataBean;
 
 import org.fenixedu.bennu.core.domain.Bennu;
 
@@ -40,13 +39,10 @@ public class MobilityProgramProvider implements DataProvider {
 
     @Override
     public Object provide(Object source, Object currentValue) {
-        MobilityStudentDataBean bean = (MobilityStudentDataBean) source;
         Set<MobilityProgram> mobilityPrograms =
                 new TreeSet<MobilityProgram>(MobilityProgram.COMPARATOR_BY_REGISTRATION_AGREEMENT);
         for (MobilityAgreement agreement : Bennu.getInstance().getMobilityAgreementsSet()) {
-            if (agreement.getUniversityUnit() == bean.getSelectedUniversity()) {
-                mobilityPrograms.add(agreement.getMobilityProgram());
-            }
+            mobilityPrograms.add(agreement.getMobilityProgram());
         }
         return mobilityPrograms;
     }

--- a/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/internationalRelatOffice/candidacy/erasmus/ErasmusCandidacyProcessDA.java
+++ b/src/main/java/net/sourceforge/fenixedu/presentationTier/Action/internationalRelatOffice/candidacy/erasmus/ErasmusCandidacyProcessDA.java
@@ -188,9 +188,11 @@ public class ErasmusCandidacyProcessDA extends
         MobilityApplicationProcess process = getProcess(request);
         ErasmusVacancyBean bean = getErasmusVacancyBean();
 
-        if (process.getCandidacyPeriod().existsFor(bean.getMobilityAgreement(), bean.getDegree())) {
-            addActionMessage(request, "error.erasmus.insert.vacancy.already.exists");
-            return mapping.findForward("insert-university-agreement");
+        for (Degree degree : bean.getDegrees()) {
+            if (process.getCandidacyPeriod().existsFor(bean.getMobilityAgreement(), degree)) {
+                addActionMessage(request, "error.erasmus.insert.vacancy.already.exists");
+                return mapping.findForward("insert-university-agreement");
+            }
         }
 
         executeActivity(getProcess(request), "InsertMobilityQuota", bean);

--- a/src/main/webapp/WEB-INF/fenix/schemas/caseHandling-schemas.xml
+++ b/src/main/webapp/WEB-INF/fenix/schemas/caseHandling-schemas.xml
@@ -2349,8 +2349,9 @@
 </schema> 
 
 <schema name="ErasmusIndividualCandidacyProcess.university.edit" type="net.sourceforge.fenixedu.domain.candidacyProcess.mobility.MobilityStudentDataBean" bundle="ACADEMIC_OFFICE_RESOURCES">
-	<slot name="selectedMobilityProgram" key="label.mobility.program" layout="menu-select" read-only="true">
-		<property name="format" value="${registrationAgreement}" />
+	<slot name="selectedMobilityProgram" key="label.mobility.program" layout="menu-select-postback">
+		<property name="format" value="${name}" />
+		<property name="destination" value="chooseMobilityProgramPostback"/>
 		<property name="providerClass" value="net.sourceforge.fenixedu.presentationTier.Action.candidacy.erasmus.MobilityProgramProvider" />
 		<validator class="pt.ist.fenixWebFramework.renderers.validators.RequiredValidator"/>
 	</slot>
@@ -2771,15 +2772,29 @@
 	</slot>	
 </schema>
 
-<schema name="ErasmusVacancy.insert.choose.degree" type="net.sourceforge.fenixedu.domain.candidacyProcess.erasmus.ErasmusVacancyBean" bundle="ACADEMIC_OFFICE_RESOURCES">
-	<slot name="degree" key="label.erasmus.degree" layout="menu-select" >
-		<property name="format" value="${presentationName}" />
+<schema name="ErasmusVacancy.modify.choosen.degree" type = "net.sourceforge.fenixedu.domain.candidacyProcess.mobility.MobilityIndividualApplicationProcessBean"  bundle="ACADEMIC_OFFICE_RESOURCES">
+	<slot name="degree" key="label.eramsus.candidacy.choosed.degree" layout="menu-select" >
 		<property name="providerClass" value="net.sourceforge.fenixedu.presentationTier.Action.candidacy.erasmus.ErasmusCandidacyProcessDA$ErasmusCandidacyDegreesProvider" />
+		<property name="format" value="${presentationName}"/>
+		<validator class="pt.ist.fenixWebFramework.renderers.validators.RequiredValidator"/>
+	</slot>
+</schema>
+
+<schema name="ErasmusVacancy.insert.choose.degree" type="net.sourceforge.fenixedu.domain.candidacyProcess.erasmus.ErasmusVacancyBean" bundle="ACADEMIC_OFFICE_RESOURCES">
+	<slot name="degrees" key="label.erasmus.degree" layout="option-select" >
+		<property name="providerClass" value="net.sourceforge.fenixedu.presentationTier.Action.candidacy.erasmus.ErasmusCandidacyProcessDA$ErasmusCandidacyDegreesProvider" />
+		<property name="eachSchema" value="ErasmusVacancy.degree.name" />
+		<property name="eachLayout" value="values"/>
+		<property name="classes" value="nobullet noindent"/>
 		<validator class="pt.ist.fenixWebFramework.renderers.validators.RequiredValidator"/>
 	</slot>
 	<slot name="numberOfVacancies" key="label.erasmus.insertVacancy.number.vacancies">
 		<validator class="pt.ist.fenixWebFramework.renderers.validators.RequiredValidator"/>
 	</slot>
+</schema>
+
+<schema name="ErasmusVacancy.degree.name" type="net.sourceforge.fenixedu.domain.Degree">
+	<slot name="presentationName" />
 </schema>
 
 <schema name="MobilityCoordinator.list" type="net.sourceforge.fenixedu.domain.candidacyProcess.mobility.MobilityCoordinator" bundle="ACADEMIC_OFFICE_RESOURCES">

--- a/src/main/webapp/candidacy/erasmus/editDegreeAndCoursesInformation.jsp
+++ b/src/main/webapp/candidacy/erasmus/editDegreeAndCoursesInformation.jsp
@@ -71,6 +71,7 @@
 	        <fr:property name="columnClasses" value="width12em,,tdclear tderror1"/>
 		</fr:layout>
 		<fr:destination name="chooseCountryPostback" path="<%= "/caseHandlingMobilityIndividualApplicationProcess.do?userAction=editCandidacy&method=chooseCountry&amp;processId=" + processId.toString() %>"/>
+		<fr:destination name="chooseMobilityProgramPostback" path="<%= "/caseHandlingMobilityIndividualApplicationProcess.do?userAction=editCandidacy&method=chooseMobilityProgram&amp;processId=" + processId.toString() %>"/>
 		<fr:destination name="chooseUniversityPostback" path="<%= "/caseHandlingMobilityIndividualApplicationProcess.do?userAction=editCandidacy&method=chooseUniversity&amp;processId=" + processId.toString() %>"/>
 	</fr:edit>
 </fr:form>
@@ -112,7 +113,16 @@
 		        <fr:property name="columnClasses" value="width12em,,tdclear tderror1"/>
 			</fr:layout>
 	</fr:view>
-		
+	
+	<p>
+				<fr:edit name="individualCandidacyProcessBean" schema="ErasmusVacancy.modify.choosen.degree">
+					<fr:layout name="tabular">
+						<fr:property name="classes" value="tstyle4 thlight thright mtop025"/>
+	        			<fr:property name="columnClasses" value="width12em,width40em,tdclear error0"/>
+					</fr:layout>
+				</fr:edit>
+			</p>
+
 	<logic:notEqual name="onlyAllowedDegreeEnrolment" value="true">
 		<div class="mtop3">		
 			<p><em><bean:message key="message.erasmus.select.courses.of.associated.degrees" bundle="ACADEMIC_OFFICE_RESOURCES" /></em></p>
@@ -150,15 +160,10 @@
 			</tr>
 			</logic:iterate>
 			</table>
-		
-			<p>
-				<strong><bean:message key="label.eramsus.candidacy.choosed.degree" bundle="ACADEMIC_OFFICE_RESOURCES" /></strong>:
-				<fr:view	name="individualCandidacyProcessBean" property="selectedCourseNameForView"/>
-			</p>
 			
 		</div>
 	</logic:notEqual>
-	
+
 	<logic:equal name="onlyAllowedDegreeEnrolment" value="true">
 		<div class="mtop3">		
 			<fr:edit id="mobility.individual.application" name="mobilityIndividualApplicationProcessBean">


### PR DESCRIPTION
Removed Bolonha 1st cycle degrees from incoming mobility programmes options.
Added support for modifying a student's mobility programme.
Modified criation of incoming mobility vacancies to allow the creation of multiple vacancies at the same time
Added support for modifying a student's chosen degree.
Closes #522
