### PR TITLE
fixed restricted section access link

### DIFF
--- a/src/main/webapp/commons/sites/public/section.jsp
+++ b/src/main/webapp/commons/sites/public/section.jsp
@@ -53,7 +53,7 @@
 							    final String server = request.getServerName();
 							    final int port = request.getServerPort();
 		%>
-				<a href="<%= "https://barra.tecnico.ulisboa.pt/login?next=https://id.ist.utl.pt/cas/login?service=" + schema + "://" + server + (port == 80 || port == 443 ? "" : ":" + port) + section.getFullPath() %>">
+				<a href="<%= "https://barra.tecnico.ulisboa.pt/login?next=https://id.ist.utl.pt/cas/login?service=" + section.getFullPath() %>">
             		<bean:message key="link.section.view.login" bundle="SITE_RESOURCES"/>
        			</a>.
 		<%


### PR DESCRIPTION
removed "schema + "://" + server + (port == 80 || port == 443 ? "" : ":" + port) +" from the link to prevent links with duplicated url's, such as this:

https://barra.tecnico.ulisboa.pt/login?next=https://id.ist.utl.pt/cas/login?service= **https://fenix.tecnico.ulisboa.pthttps://fenix.tecnico.ulisboa.pt** 
/disciplinas/IIPM5/2013-2014/2-semestre/pautas-e-solucoes

from being created.
