### PR TITLE
Omitted the fields that try to edit the institution name and work location of Phd participants.

### DIFF
--- a/src/main/java/net/sourceforge/fenixedu/domain/phd/InternalPhdParticipant.java
+++ b/src/main/java/net/sourceforge/fenixedu/domain/phd/InternalPhdParticipant.java
@@ -121,7 +121,7 @@ public class InternalPhdParticipant extends InternalPhdParticipant_Base {
 
     @Override
     public String getInstitution() {
-        return UnitAcronym.readUnitAcronymByAcronym("utl").getUnitsSet().iterator().next().getName();
+        return getRootDomainObject().getInstitutionUnit().getParentUnits().iterator().next().getName();
     }
 
     @Override

--- a/src/main/webapp/phd/academicAdminOffice/participant/editPhdParticipant.jsp
+++ b/src/main/webapp/phd/academicAdminOffice/participant/editPhdParticipant.jsp
@@ -58,8 +58,6 @@
 				<fr:schema bundle="PHD_RESOURCES" type="net.sourceforge.fenixedu.domain.phd.InternalPhdParticipant">
 					<fr:slot name="title" />
 					<fr:slot name="category" />
-					<fr:slot name="workLocation" />
-					<fr:slot name="institution" />
 				</fr:schema>
 			</logic:equal>
 			


### PR DESCRIPTION
These fields were omitted from the interface, only for InternalPhdParticipant, because it's not supposed to be editable.
close #548
