### PR TITLE
Update JSP files used in first year candidate report

### DIFF
--- a/src/main/webapp/candidate/degree/printGratuityPaymentCodes.jsp
+++ b/src/main/webapp/candidate/degree/printGratuityPaymentCodes.jsp
@@ -18,6 +18,9 @@
     along with FenixEdu Core.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
+
+<%-- WARNING: This JSP is used to generate the first year candidate report (printAllDocuments.jsp). Beware when editing it! --%>
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>

--- a/src/main/webapp/candidate/degree/printMeasurementTestDate.jsp
+++ b/src/main/webapp/candidate/degree/printMeasurementTestDate.jsp
@@ -18,6 +18,9 @@
     along with FenixEdu Core.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
+
+<%-- WARNING: This JSP is used to generate the first year candidate report (printAllDocuments.jsp). Beware when editing it! --%>
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>

--- a/src/main/webapp/candidate/degree/printRegistrationDeclaration.jsp
+++ b/src/main/webapp/candidate/degree/printRegistrationDeclaration.jsp
@@ -18,6 +18,9 @@
     along with FenixEdu Core.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
+
+<%-- WARNING: This JSP is used to generate the first year candidate report (printAllDocuments.jsp). Beware when editing it! --%>
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>

--- a/src/main/webapp/candidate/degree/printUnder23TransportsDeclaration.jsp
+++ b/src/main/webapp/candidate/degree/printUnder23TransportsDeclaration.jsp
@@ -18,6 +18,9 @@
     along with FenixEdu Core.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
+
+<%-- WARNING: This JSP is used to generate the first year candidate report (printAllDocuments.jsp). Beware when editing it! --%>
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>

--- a/src/main/webapp/commons/student/timeTable/classTimeTable.jsp
+++ b/src/main/webapp/commons/student/timeTable/classTimeTable.jsp
@@ -18,6 +18,9 @@
     along with FenixEdu Core.  If not, see <http://www.gnu.org/licenses/>.
 
 --%>
+
+<%-- WARNING: This JSP is used to generate the first year candidate report (printAllDocuments.jsp). Beware when editing it! --%>
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
@@ -36,9 +39,9 @@
 	<body>
 		<logic:present name="LOGGED_USER_ATTRIBUTE">
 			<div class="mbottom2" style="font-size: 0.85em; margin-left: 3em;">
-				<p class="mvert05"><strong style="font-weight: bold;"><bean:message  key="label.name" bundle="APPLICATION_RESOURCES"/></strong>: ${LOGGED_USER_ATTRIBUTE.person.name}</p>
-				<p class="mvert05"><strong style="font-weight: bold;"><bean:message  key="label.studentNumber" bundle="APPLICATION_RESOURCES"/> </strong>: ${LOGGED_USER_ATTRIBUTE.person.student.number} </p>
-				<p class="mvert05"><strong style="font-weight: bold;"><bean:message  key="label.istUsername"  bundle="APPLICATION_RESOURCES"/> </strong>: ${LOGGED_USER_ATTRIBUTE.username} </p>
+				<p class="mvert05"><strong style="font-weight: bold;"><bean:message  key="label.name" bundle="APPLICATION_RESOURCES"/></strong>: ${person.name}</p>
+				<p class="mvert05"><strong style="font-weight: bold;"><bean:message  key="label.studentNumber" bundle="APPLICATION_RESOURCES"/> </strong>: ${person.student.number} </p>
+				<p class="mvert05"><strong style="font-weight: bold;"><bean:message  key="label.istUsername"  bundle="APPLICATION_RESOURCES"/> </strong>: ${person.username} </p>
 			</div>
 
 		</logic:present>


### PR DESCRIPTION
Added a warning message in JSP files that are used in the first year candidate report
Updated the header of the timeTable jsp
