### PR TITLE
Forces the use of 3 letter country code

### DIFF
--- a/src/main/java/org/fenixedu/academic/bootstrap/FenixBootstrapper.java
+++ b/src/main/java/org/fenixedu/academic/bootstrap/FenixBootstrapper.java
@@ -89,7 +89,9 @@ public class FenixBootstrapper {
     public static List<BootstrapError> boostrap(SchoolSetupSection schoolSetupSection, PortalSection portalSection,
             AdminUserSection adminSection) {
 
-        if (Planet.getEarth().getByAlfa3(schoolSetupSection.getCountryCode()) == null) {
+        if (Planet.getEarth().getByAlfa3(schoolSetupSection.getCountryCode()) == null
+                || !Planet.getEarth().getByAlfa3(schoolSetupSection.getCountryCode()).alpha3.equals(schoolSetupSection
+                        .getCountryCode())) {
             return singletonList(new BootstrapError(SchoolSetupSection.class, "getCountryCode", "bootstrapper.error.contry",
                     Bundle.APPLICATION));
         }


### PR DESCRIPTION
The 3 letter country code is now verified correctly and produces the desired BootstrapError f an incorrect code is sent. Be it an incorrect one or a two letter country code.

Fixes: https://jira.fenixedu.org/browse/ACADEMIC-333