### PR TITLE
Fixed search space by person

### DIFF
--- a/src/main/java/org/fenixedu/academic/api/beans/publico/FenixSpace.java
+++ b/src/main/java/org/fenixedu/academic/api/beans/publico/FenixSpace.java
@@ -37,7 +37,8 @@ import com.google.common.collect.FluentIterable;
 @JsonSubTypes({ @JsonSubTypes.Type(value = FenixSpace.Campus.class, name = "CAMPUS"),
         @JsonSubTypes.Type(value = FenixSpace.Building.class, name = "BUILDING"),
         @JsonSubTypes.Type(value = FenixSpace.Floor.class, name = "FLOOR"),
-        @JsonSubTypes.Type(value = FenixSpace.Room.class, name = "ROOM") })
+        @JsonSubTypes.Type(value = FenixSpace.Room.class, name = "ROOM"),
+        @JsonSubTypes.Type(value = FenixSpace.RoomSubdivision.class, name = "ROOM_SUBDIVISION") })
 public class FenixSpace {
 
     public static class Campus extends FenixSpace {
@@ -220,9 +221,11 @@ public class FenixSpace {
         if (SpaceUtils.isFloor(space)) {
             return new FenixSpace.Floor(space, withParentAndContainedSpaces);
         }
-
         if (SpaceUtils.isRoom(space)) {
             return new FenixSpace.Room(space, withParentAndContainedSpaces);
+        }
+        if (SpaceUtils.isRoomSubdivision(space)) {
+            return new FenixSpace.RoomSubdivision(space, withParentAndContainedSpaces);
         }
 
         return null;

--- a/src/main/java/org/fenixedu/academic/dto/InfoLesson.java
+++ b/src/main/java/org/fenixedu/academic/dto/InfoLesson.java
@@ -31,6 +31,10 @@ import org.fenixedu.academic.domain.ShiftType;
 import org.fenixedu.academic.util.DiaSemana;
 import org.joda.time.YearMonthDay;
 
+import pt.ist.fenixframework.FenixFramework;
+
+import com.google.common.base.Strings;
+
 public class InfoLesson extends InfoShowOccupation implements Comparable<InfoLesson> {
 
     private final static Comparator<InfoLesson> INFO_LESSON_COMPARATOR_CHAIN = new Comparator<InfoLesson>() {
@@ -51,14 +55,12 @@ public class InfoLesson extends InfoShowOccupation implements Comparable<InfoLes
 
     };
 
-    private final Lesson lesson;
     private InfoRoom infoSala;
     private InfoShift infoShift;
     private InfoRoomOccupation infoRoomOccupation;
 
     public InfoLesson(Lesson lesson) {
         super.copyFromDomain(lesson);
-        this.lesson = lesson;
     }
 
     @Override
@@ -174,7 +176,13 @@ public class InfoLesson extends InfoShowOccupation implements Comparable<InfoLes
     }
 
     public Lesson getLesson() {
-        return lesson;
+        if (!Strings.isNullOrEmpty(getExternalId())) {
+            Lesson lesson = FenixFramework.getDomainObject(getExternalId());
+            if (FenixFramework.isDomainObjectValid(lesson)) {
+                return lesson;
+            }
+        }
+        return null;
     }
 
     public String getOccurrenceWeeksAsString() {

--- a/src/main/java/org/fenixedu/academic/dto/spaceManager/FindSpacesBean.java
+++ b/src/main/java/org/fenixedu/academic/dto/spaceManager/FindSpacesBean.java
@@ -22,13 +22,16 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.fenixedu.academic.domain.space.SpaceUtils;
 import org.fenixedu.academic.domain.space.WrittenEvaluationSpaceOccupation;
 import org.fenixedu.academic.domain.time.calendarStructure.AcademicInterval;
 import org.fenixedu.academic.dto.LinkObject;
+import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.spaces.domain.Space;
 import org.fenixedu.spaces.domain.occupation.Occupation;
+import org.fenixedu.spaces.domain.occupation.SharedOccupation;
 
 public class FindSpacesBean implements Serializable {
 
@@ -92,7 +95,7 @@ public class FindSpacesBean implements Serializable {
 
     public static enum SpacesSearchCriteriaType {
 
-        SPACE, /*PERSON,*/EXECUTION_COURSE, WRITTEN_EVALUATION;
+        SPACE, PERSON, EXECUTION_COURSE, WRITTEN_EVALUATION;
 
         public String getName() {
             return name();
@@ -192,5 +195,10 @@ public class FindSpacesBean implements Serializable {
     public Integer getExamCapacity() {
         Optional<Integer> metadata = getSpace().getMetadata("examCapacity");
         return metadata.isPresent() ? metadata.get() : 0;
+    }
+
+    public List<User> getOccupants() {
+        return getSpace().getOccupationSet().stream().filter(occ -> occ instanceof SharedOccupation && occ.isActive())
+                .map(occ -> (SharedOccupation) occ).map(so -> so.getUser()).distinct().collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/fenixedu/academic/ui/struts/action/publico/spaces/FindSpacesDA.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/publico/spaces/FindSpacesDA.java
@@ -243,15 +243,18 @@ public class FindSpacesDA extends FenixDispatchAction {
         BlueprintFile mostRecentBlueprint = spaceWithBlueprint.getBlueprintFile().get();
 
         if (mostRecentBlueprint != null) {
+            try {
+                final byte[] blueprintBytes = mostRecentBlueprint.getContent();
+                final InputStream inputStream = new ByteArrayInputStream(blueprintBytes);
+                BlueprintTextRectangles blueprintTextRectangles =
+                        SpaceBlueprintsDWGProcessor.getBlueprintTextRectangles(inputStream, spaceWithBlueprint, now, false,
+                                false, true, false, null);
 
-            final byte[] blueprintBytes = mostRecentBlueprint.getContent();
-            final InputStream inputStream = new ByteArrayInputStream(blueprintBytes);
-            BlueprintTextRectangles blueprintTextRectangles =
-                    SpaceBlueprintsDWGProcessor.getBlueprintTextRectangles(inputStream, spaceWithBlueprint, now, false, false,
-                            true, false, null);
+                request.setAttribute("mostRecentBlueprint", mostRecentBlueprint);
+                request.setAttribute("blueprintTextRectangles", blueprintTextRectangles);
+            } catch (Exception ioe) {
 
-            request.setAttribute("mostRecentBlueprint", mostRecentBlueprint);
-            request.setAttribute("blueprintTextRectangles", blueprintTextRectangles);
+            }
         }
     }
 }

--- a/src/main/resources/resources/ApplicationResources_en.properties
+++ b/src/main/resources/resources/ApplicationResources_en.properties
@@ -5077,6 +5077,7 @@ link.unEnrollStudentGroupShift = Dissociating Shift
 link.validateTestChecksum = Validate code
 link.view = View
 link.view.schedule = Hours
+link.view.occupants = Occupants
 link.view.space = View
 link.view.teacher.credits.sheet = Service Professor
 link.view.written.evaluations = Reviews

--- a/src/main/resources/resources/ApplicationResources_pt.properties
+++ b/src/main/resources/resources/ApplicationResources_pt.properties
@@ -5083,6 +5083,7 @@ link.unEnrollStudentGroupShift = Dissociar Turno
 link.validateTestChecksum = Validar código
 link.view = Ver
 link.view.schedule = Horário
+link.view.occupants = Ocupantes
 link.view.space = Ver
 link.view.teacher.credits.sheet = Serviço do Docente
 link.view.written.evaluations = Avaliações

--- a/src/main/webapp/publico/spaces/findSpaces.jsp
+++ b/src/main/webapp/publico/spaces/findSpaces.jsp
@@ -54,14 +54,27 @@
 .form1 table ul li * {
 display: inline !important;
 }
+
+.form1 li {
+	display: inline;
+	min-width: 6em;
+	float: left;
+	white-space:nowrap;
+}
+
+.form1 input[type="radio"] {
+	float: left;
+	margin: 0.65em 0.2em 0.4em 0em;
+}
+
 </style>
 
 
 	<fr:form id="searchform" action="/findSpaces.do">
+		<h3><bean:message key="label.find" bundle="DEFAULT"/></h3>
 		<div class="form1">
 			<html:hidden name="findSpacesForm" property="method" value="search"/>				
 			<fieldset>
-				<legend><bean:message key="label.find" bundle="DEFAULT"/></legend>
 				
 				<fr:edit id="beanWithLabelToSearchID" name="bean" schema="<%= schemaName %>">
 					<fr:destination name="postBack" path="/findSpaces.do?method=prepareSearchSpacesPostBack"/>	
@@ -111,7 +124,7 @@ display: inline !important;
 				<fr:property name="rowClasses" value=",bluecell" />
 				
 				<fr:property name="link(viewSchedule)" value="/viewRoom.do?method=roomViewer" />
-				<fr:property name="param(viewSchedule)" value="space.name/roomName" />
+				<fr:property name="param(viewSchedule)" value="space.externalId/roomId,space.name/roomName" />
 				<fr:property name="key(viewSchedule)" value="link.view.schedule" />
 				<fr:property name="bundle(viewSchedule)" value="DEFAULT" />
 				<fr:property name="order(viewSchedule)" value="0" />
@@ -126,7 +139,6 @@ display: inline !important;
 											
 			</fr:layout>
 		</fr:view>
-		
 	</logic:notEmpty>
 
 </logic:notEmpty>

--- a/src/main/webapp/publico/spaces/viewSelectedSpace.jsp
+++ b/src/main/webapp/publico/spaces/viewSelectedSpace.jsp
@@ -36,7 +36,7 @@
 	<p class="mtop15 mbottom05">
 		<html:link page="/findSpaces.do?method=prepareSearchSpaces"> &laquo; <bean:message key="link.search.for.spaces.again"/></html:link>		
 	</p>
-
+	
 	<fr:view name="selectedSpace">	
 		<fr:schema type="org.fenixedu.academic.dto.spaceManager.FindSpacesBean" bundle="DEFAULT">
 			<fr:slot name="space.presentationName" key="label.find.spaces.space.name"/>
@@ -62,7 +62,7 @@
 
 	<ul>
 		<logic:equal name="selectedSpace" property="withSchedule" value="true">
-			<bean:define id="viewScheduleLink">/viewRoom.do?method=roomViewer&amp;roomName=<bean:write name="selectedSpace" property="space.name"/></bean:define>				
+			<bean:define id="viewScheduleLink">/viewRoom.do?method=roomViewer&amp;roomName=<bean:write name="selectedSpace" property="space.name"/>&amp;roomId=<bean:write name="selectedSpace" property="space.externalId"/></bean:define>				
 			<li><html:link target="_blank" page="<%= viewScheduleLink %>"><bean:message key="link.view.schedule"/></html:link></li>
 		</logic:equal>
 			
@@ -110,6 +110,41 @@
  			</div>
 		</div>									
 	
+	</logic:notEmpty>	
+	
+	<logic:notEmpty name="selectedSpace" property="occupants">
+		<bean:define id="users" name="selectedSpace" property="occupants"/>
+		<table class="tstyle2 thlight thleft mtop15 table">
+			<tbody>
+				<tr>
+					<th scope="row">
+						<bean:message key="link.view.occupants"/>
+					</th>
+				</tr>
+				<logic:iterate id="user" name="users">
+					<bean:define id="username" name="user" property="name"/>
+					<bean:define id="person" name="user" property="person"/>
+					<bean:define id="justName" value="true"/>
+					<logic:notEmpty name="person">
+						<logic:notEmpty name="person" property="defaultWebAddressUrl">
+							<tr>
+								<td>
+									<a href="<bean:write name="person" property="defaultWebAddressUrl"/>"><bean:write name="username"/></a>
+								</td>
+							</tr>
+							<bean:define id="justName" value="false"/>
+						</logic:notEmpty>
+					</logic:notEmpty>
+					<logic:equal name="justName" value="true">
+						<tr>
+							<td>
+								<bean:write name="username"/>
+							</td>
+						</tr>
+					</logic:equal>
+				</logic:iterate>
+			</tbody>
+		</table>
 	</logic:notEmpty>
 	
 	<logic:notEmpty name="containedSpaces">

--- a/src/main/webapp/publico/viewRoom_bd.jsp
+++ b/src/main/webapp/publico/viewRoom_bd.jsp
@@ -33,8 +33,11 @@
 
 <html:form action="/viewRoom">
 	<bean:define id="room" name="infoRoom" property="nome"/>
+	<bean:define id="roomId" name="infoRoom" property="externalId"/>
 	<html:hidden bundle="HTMLALT_RESOURCES" altKey="hidden.method" property="method" value="roomViewer"/>
 	<html:hidden bundle="HTMLALT_RESOURCES" altKey="hidden.roomName" property="roomName" value="<%=room.toString()%>"/>
+	<html:hidden property="roomId" value="<%=roomId.toString()%>"/>
+	
 	<html:hidden bundle="HTMLALT_RESOURCES" altKey="hidden.page" property="page" value="1"/>
 
 	<table>


### PR DESCRIPTION
The interface is now re-enabled and adapted to the new fenixedu-spaces.
The layoyt was fixed as the elements, instead of being displayed inline, were stacked.
In the resulting page we now check if the blueprint exists before printing it.
Also in the resulting page, the occupants name are displayed, with the link to their webpages if these are available