### PR TITLE
getTeacherAuthorization: Check for an equal interval instead a overlapped one. ACDM-669 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/Teacher.java
+++ b/src/main/java/org/fenixedu/academic/domain/Teacher.java
@@ -392,7 +392,7 @@ public class Teacher extends Teacher_Base {
     }
 
     public Optional<TeacherAuthorization> getTeacherAuthorization(AcademicInterval interval) {
-        return getTeacherAuthorizationStream().filter(a -> a.getExecutionSemester().getAcademicInterval().overlaps(interval))
+        return getTeacherAuthorizationStream().filter(a -> a.getExecutionSemester().getAcademicInterval().equals(interval))
                 .findFirst();
     }
 


### PR DESCRIPTION
getTeacherAuthorization(AcademicInterval): Check for an equal interval instead a overlapped one.