### PR TITLE
Made pre-bologna degree codes visible in the curricular plan management interface

### DIFF
--- a/src/main/webapp/academicAdministration/bolonha/curricularPlans/curricularPlansManagement.jsp
+++ b/src/main/webapp/academicAdministration/bolonha/curricularPlans/curricularPlansManagement.jsp
@@ -118,7 +118,10 @@
 			<h:outputText value="<table style='width: 90%' class='showinfo1 bgcolor1'>" escape="false"/>
 			<h:outputText value="<tr><th width='80px'><strong>#{bolonhaBundle['degree']}:</strong></th>" escape="false"/>
 	
-			<h:outputText value="<td> #{degree.presentationName} (#{degree.sigla})</td>" escape="false"/>
+			<h:outputText value="<td> #{degree.presentationName} (#{degree.sigla})" escape="false"/>
+				<h:outputText value=" [#{degree.code}]" rendered="#{!empty degree.code}" escape="false"/>
+			<h:outputText value="</td>" escape="false"/>
+			
 			<h:outputText value="<td style='width: 300px'>" escape="false"/>
 			<h:outputLink value="#{AcademicAdministrationDegreeManagement.request.contextPath}/academicAdministration/bolonha/curricularPlans/viewDegree.faces">
 				<h:outputFormat value="#{bolonhaBundle['view']}"/>


### PR DESCRIPTION
This improvement is part of the scope of the already closed issue https://jira.fenixedu.org/browse/ACDM-626
