### PR TITLE
ACDM-690 #comment Requested cycle can be null in conclusion document requests

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/serviceRequests/documentRequests/DegreeFinalizationCertificateRequest.java
+++ b/src/main/java/org/fenixedu/academic/domain/serviceRequests/documentRequests/DegreeFinalizationCertificateRequest.java
@@ -254,13 +254,8 @@ public class DegreeFinalizationCertificateRequest extends DegreeFinalizationCert
 
     @Override
     public CycleType getRequestedCycle() {
-        Optional<CurriculumGroup> curriculumGroup = getProgramConclusion().groupFor(getRegistration());
-
-        if (!curriculumGroup.isPresent() || !curriculumGroup.get().isCycleCurriculumGroup()) {
-            throw new DomainException("error.no.cycle.group.present");
-        }
-
-        return ((CycleCurriculumGroup) curriculumGroup.get()).getCycleType();
+        return getProgramConclusion().groupFor(getRegistration()).filter(CurriculumGroup::isCycleCurriculumGroup)
+                .map(ccg -> ((CycleCurriculumGroup) ccg).getCycleType()).orElse(null);
     }
 
     @Override

--- a/src/main/java/org/fenixedu/academic/domain/serviceRequests/documentRequests/DiplomaRequest.java
+++ b/src/main/java/org/fenixedu/academic/domain/serviceRequests/documentRequests/DiplomaRequest.java
@@ -39,7 +39,6 @@ package org.fenixedu.academic.domain.serviceRequests.documentRequests;
 import static org.fenixedu.academic.predicate.AccessControl.check;
 
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 
 import org.fenixedu.academic.domain.ExecutionYear;
@@ -240,13 +239,8 @@ public class DiplomaRequest extends DiplomaRequest_Base implements IDiplomaReque
 
     @Override
     public CycleType getRequestedCycle() {
-        Optional<CurriculumGroup> curriculumGroup = getProgramConclusion().groupFor(getRegistration());
-
-        if (!curriculumGroup.isPresent() || !curriculumGroup.get().isCycleCurriculumGroup()) {
-            throw new DomainException("error.no.cycle.group.present");
-        }
-
-        return ((CycleCurriculumGroup) curriculumGroup.get()).getCycleType();
+        return getProgramConclusion().groupFor(getRegistration()).filter(CurriculumGroup::isCycleCurriculumGroup)
+                .map(cg -> ((CycleCurriculumGroup) cg).getCycleType()).orElse(null);
     }
 
     public CurriculumGroup getCurriculumGroup() {

--- a/src/main/java/org/fenixedu/academic/domain/serviceRequests/documentRequests/DiplomaSupplementRequest.java
+++ b/src/main/java/org/fenixedu/academic/domain/serviceRequests/documentRequests/DiplomaSupplementRequest.java
@@ -19,7 +19,6 @@
 package org.fenixedu.academic.domain.serviceRequests.documentRequests;
 
 import java.util.Locale;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.fenixedu.academic.domain.Degree;
@@ -251,13 +250,8 @@ public class DiplomaSupplementRequest extends DiplomaSupplementRequest_Base impl
 
     @Override
     public CycleType getRequestedCycle() {
-        Optional<CurriculumGroup> curriculumGroup = getProgramConclusion().groupFor(getRegistration());
-
-        if (!curriculumGroup.isPresent() || !curriculumGroup.get().isCycleCurriculumGroup()) {
-            throw new DomainException("error.no.cycle.group.present");
-        }
-
-        return ((CycleCurriculumGroup) curriculumGroup.get()).getCycleType();
+        return getProgramConclusion().groupFor(getRegistration()).filter(CurriculumGroup::isCycleCurriculumGroup)
+                .map(cg -> ((CycleCurriculumGroup) cg).getCycleType()).orElse(null);
     }
 
     @Override

--- a/src/main/java/org/fenixedu/academic/domain/serviceRequests/documentRequests/RegistryDiplomaRequest.java
+++ b/src/main/java/org/fenixedu/academic/domain/serviceRequests/documentRequests/RegistryDiplomaRequest.java
@@ -19,7 +19,6 @@
 package org.fenixedu.academic.domain.serviceRequests.documentRequests;
 
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 
 import org.fenixedu.academic.domain.ExecutionYear;
@@ -207,13 +206,8 @@ public class RegistryDiplomaRequest extends RegistryDiplomaRequest_Base implemen
 
     @Override
     public CycleType getRequestedCycle() {
-        Optional<CurriculumGroup> curriculumGroup = getProgramConclusion().groupFor(getRegistration());
-
-        if (!curriculumGroup.isPresent() || !curriculumGroup.get().isCycleCurriculumGroup()) {
-            throw new DomainException("error.no.cycle.group.present");
-        }
-
-        return ((CycleCurriculumGroup) curriculumGroup.get()).getCycleType();
+        return getProgramConclusion().groupFor(getRegistration()).filter(CurriculumGroup::isCycleCurriculumGroup)
+                .map(cg -> ((CycleCurriculumGroup) cg).getCycleType()).orElse(null);
     }
 
     @Override

--- a/src/main/java/org/fenixedu/academic/domain/student/Registration.java
+++ b/src/main/java/org/fenixedu/academic/domain/student/Registration.java
@@ -1666,7 +1666,7 @@ public class Registration extends Registration_Base {
     @Deprecated
     final public String getDegreeDescription(ExecutionYear executionYear, final CycleType cycleType, final Locale locale) {
         CycleCourseGroup cycleCourseGroup = getLastStudentCurricularPlan().getCycleCourseGroup(cycleType);
-        if (cycleCourseGroup.getProgramConclusion() != null) {
+        if (cycleCourseGroup != null && cycleCourseGroup.getProgramConclusion() != null) {
             return getDegreeDescription(executionYear, cycleCourseGroup.getProgramConclusion(), locale);
         }
         return "";

--- a/src/main/java/org/fenixedu/academic/report/academicAdministrativeOffice/Diploma.java
+++ b/src/main/java/org/fenixedu/academic/report/academicAdministrativeOffice/Diploma.java
@@ -186,7 +186,7 @@ public class Diploma extends AdministrativeOfficeDocument {
     private void forOthers(StringBuilder result, final DiplomaRequest diplomaRequest, final Registration registration) {
         final DegreeType degreeType = registration.getDegreeType();
 
-        if (degreeType.hasAnyCycleTypes()) {
+        if (degreeType.hasAnyCycleTypes() && diplomaRequest.getRequestedCycle() != null) {
             result.append(BundleUtil.getString(Bundle.ENUMERATION, getLocale(), diplomaRequest.getRequestedCycle()
                     .getQualifiedName()));
             result.append(SINGLE_SPACE).append(BundleUtil.getString(Bundle.APPLICATION, getLocale(), "of.masculine"))
@@ -223,6 +223,15 @@ public class Diploma extends AdministrativeOfficeDocument {
         }
 
         return "diploma.supplement.qualifiedgrade." + qualifiedAverageGrade;
+    }
+
+    @Override
+    protected String getDegreeDescription() {
+        if (getRegistration() == null) {
+            return super.getDegreeDescription();
+        }
+        return getRegistration().getDegreeDescription(getRegistration().getStartExecutionYear(),
+                getDocumentRequest().getProgramConclusion(), getLocale());
     }
 
 }

--- a/src/main/java/org/fenixedu/academic/report/academicAdministrativeOffice/DiplomaSupplement.java
+++ b/src/main/java/org/fenixedu/academic/report/academicAdministrativeOffice/DiplomaSupplement.java
@@ -207,7 +207,7 @@ public class DiplomaSupplement extends AdministrativeOfficeDocument {
                         + SINGLE_SPACE
                         + BundleUtil.getString(Bundle.ACADEMIC, getLocale(), "diploma.supplement.of")
                         + SINGLE_SPACE + institutionsUniversityUnit.getName());
-        if (getDocumentRequest().getRequestedCycle().equals(CycleType.FIRST_CYCLE)) {
+        if (CycleType.FIRST_CYCLE.equals(getDocumentRequest().getRequestedCycle())) {
             addParameter("languages", BundleUtil.getString(Bundle.ENUMERATION, getLocale(), "pt"));
         } else {
             addParameter(
@@ -272,7 +272,7 @@ public class DiplomaSupplement extends AdministrativeOfficeDocument {
 
     private void addProgrammeRequirements(String graduateDegree) {
         String labelThe =
-                getDocumentRequest().getRequestedCycle().equals(CycleType.FIRST_CYCLE) ? BundleUtil.getString(Bundle.ACADEMIC,
+                CycleType.FIRST_CYCLE.equals(getDocumentRequest().getRequestedCycle()) ? BundleUtil.getString(Bundle.ACADEMIC,
                         getLocale(), "label.the.female") : BundleUtil.getString(Bundle.ACADEMIC, getLocale(), "label.the.male");
         double ectsCreditsValue = getDocumentRequest().getEctsCredits();
         String ectsCredits =
@@ -316,7 +316,7 @@ public class DiplomaSupplement extends AdministrativeOfficeDocument {
     protected void addProfessionalStatus() {
         String professionalStatus;
 
-        if (!getDocumentRequest().getRequestedCycle().equals(CycleType.SECOND_CYCLE)) {
+        if (!CycleType.SECOND_CYCLE.equals(getDocumentRequest().getRequestedCycle())) {
             professionalStatus =
                     BundleUtil.getString(Bundle.ACADEMIC, getLocale(), "diploma.supplement.professionalstatus.notapplicable");
         } else {

--- a/src/main/java/org/fenixedu/academic/ui/struts/action/administrativeOffice/serviceRequests/RectorateDocumentSubmissionDispatchAction.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/administrativeOffice/serviceRequests/RectorateDocumentSubmissionDispatchAction.java
@@ -38,11 +38,9 @@ import org.apache.struts.action.ActionMapping;
 import org.fenixedu.academic.domain.accessControl.academicAdministration.AcademicAccessRule;
 import org.fenixedu.academic.domain.accessControl.academicAdministration.AcademicOperationType;
 import org.fenixedu.academic.domain.administrativeOffice.AdministrativeOffice;
-import org.fenixedu.academic.domain.degreeStructure.CycleType;
 import org.fenixedu.academic.domain.exceptions.DomainException;
 import org.fenixedu.academic.domain.serviceRequests.AcademicServiceRequest;
-import org.fenixedu.academic.domain.serviceRequests.IDiplomaRequest;
-import org.fenixedu.academic.domain.serviceRequests.IDiplomaSupplementRequest;
+import org.fenixedu.academic.domain.serviceRequests.IProgramConclusionRequest;
 import org.fenixedu.academic.domain.serviceRequests.IRegistryDiplomaRequest;
 import org.fenixedu.academic.domain.serviceRequests.RectorateSubmissionBatch;
 import org.fenixedu.academic.domain.serviceRequests.RectorateSubmissionState;
@@ -196,22 +194,9 @@ public class RectorateDocumentSubmissionDispatchAction extends FenixDispatchActi
 
                 addCell("Código", document.getRegistryCode().getCode());
                 addCell("Tipo de Documento", BundleUtil.getString(Bundle.ENUMERATION, document.getDocumentRequestType().name()));
-                switch (document.getDocumentRequestType()) {
-                case REGISTRY_DIPLOMA_REQUEST:
-                    addCell("Ciclo", BundleUtil.getString(Bundle.ENUMERATION, ((IRegistryDiplomaRequest) document)
-                            .getRequestedCycle().name()));
-                    break;
-                case DIPLOMA_REQUEST:
-                    CycleType cycle = ((IDiplomaRequest) document).getRequestedCycle();
-                    addCell("Ciclo", cycle != null ? BundleUtil.getString(Bundle.ENUMERATION, cycle.name()) : null);
-                    break;
-                case DIPLOMA_SUPPLEMENT_REQUEST:
-                    addCell("Ciclo", BundleUtil.getString(Bundle.ENUMERATION, ((IDiplomaSupplementRequest) document)
-                            .getRequestedCycle().name()));
-                    break;
-                default:
-                    addCell("Ciclo", null);
-                }
+
+                addCell("Apuramento", document instanceof IProgramConclusionRequest ? ((IProgramConclusionRequest) document)
+                        .getProgramConclusion().getName().getContent() : null);
 
                 if (document.isRequestForRegistration()) {
                     addCell("Tipo de Curso", ((DocumentRequest) document).getDegreeType().getName().getContent());

--- a/src/main/webapp/WEB-INF/fenixedu-academic/schemas/serviceRequests-schemas.xml
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/schemas/serviceRequests-schemas.xml
@@ -148,7 +148,7 @@
 <schema name="DiplomaSupplementRequest.view"
     type="org.fenixedu.academic.domain.serviceRequests.documentRequests.DiplomaSupplementRequest"
     extends="AcademicServiceRequest.view" bundle="ACADEMIC_OFFICE_RESOURCES">
-    <slot name="requestedCycle" key="label.cycleType" />
+    <slot name="requestedCycle" layout="null-as-label" key="label.cycleType" />
     <slot name="givenNames" key="label.givenNames" />
     <slot name="familyNames" key="label.familyNames" />
 </schema>

--- a/src/main/webapp/academicAdminOffice/rectorateDocumentSubmission/showBatch.jsp
+++ b/src/main/webapp/academicAdminOffice/rectorateDocumentSubmission/showBatch.jsp
@@ -88,7 +88,7 @@
 			type="org.fenixedu.academic.domain.serviceRequests.documentRequests.IRectorateSubmissionBatchDocumentEntry">
 			<fr:slot name="registryCode.code" key="label.rectorateSubmission.registryCode" />
 			<fr:slot name="documentRequestType" key="label.rectorateSubmission.registryCode" />
-			<fr:slot name="requestedCycle" key="label.rectorateSubmission.requestedCycle" />
+			<fr:slot name="requestedCycle" layout="null-as-label" key="label.rectorateSubmission.requestedCycle" />
 			<fr:slot name="programmeTypeDescription" key="label.degreeType" />
 			<fr:slot name="student.number" key="label.studentNumber" />
 			<fr:slot name="person.name" key="label.Student.Person.name" />

--- a/src/main/webapp/rectorate/showBatch.jsp
+++ b/src/main/webapp/rectorate/showBatch.jsp
@@ -77,7 +77,7 @@
 			type="org.fenixedu.academic.domain.serviceRequests.documentRequests.IRectorateSubmissionBatchDocumentEntry">
 			<fr:slot name="registryCode.code" key="label.rectorateSubmission.registryCode" />
 			<fr:slot name="documentRequestType" key="label.rectorateSubmission.registryCode" />
-			<fr:slot name="requestedCycle" key="label.rectorateSubmission.requestedCycle" />
+			<fr:slot name="requestedCycle" layout="null-as-label" key="label.rectorateSubmission.requestedCycle" />
 			<fr:slot name="programmeTypeDescription" key="label.degreeType" />
 			<fr:slot name="student.number" key="label.studentNumber" />
 			<fr:slot name="person.name" key="label.Student.Person.name" />


### PR DESCRIPTION
Program conclusion document requests enforce requested cycle for legacy
reasons.
Requested cycle can be null when the conclusion refers to a curriculum
group which is not cycle aware.

Issue: ACDM-690