### PR TITLE
Escaped EL expressions using c:out

### DIFF
--- a/src/main/webapp/WEB-INF/fenixedu-academic/configuration/ingression-type/create.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/configuration/ingression-type/create.jsp
@@ -31,7 +31,7 @@ ${portal.toolkit()}
 	<div class="alert alert-danger" role="alert">
 
 		<c:forEach items="${errorMessages}" var="message"> 
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/configuration/ingression-type/read.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/configuration/ingression-type/read.jsp
@@ -31,7 +31,7 @@
 	<div class="alert alert-danger" role="alert">
 
 		<c:forEach items="${errorMessages}" var="message"> 
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/configuration/ingression-type/search.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/configuration/ingression-type/search.jsp
@@ -29,7 +29,7 @@
 	<div class="alert alert-info" role="alert">
 
 		<c:forEach items="${infoMessages}" var="message">
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>
@@ -39,7 +39,7 @@
 	<div class="alert alert-danger" role="alert">
 
 		<c:forEach items="${errorMessages}" var="message">
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/configuration/ingression-type/update.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/configuration/ingression-type/update.jsp
@@ -33,7 +33,7 @@ ${portal.toolkit()}
 	<div class="alert alert-danger" role="alert">
 
 		<c:forEach items="${errorMessages}" var="message"> 
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>	

--- a/src/main/webapp/WEB-INF/fenixedu-academic/configuration/statutes/create.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/configuration/statutes/create.jsp
@@ -31,7 +31,7 @@ ${portal.toolkit()}
 	<div class="alert alert-danger" role="alert">
 
 		<c:forEach items="${errorMessages}" var="message">
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/configuration/statutes/read.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/configuration/statutes/read.jsp
@@ -31,7 +31,7 @@
 	<div class="alert alert-danger" role="alert">
 
 		<c:forEach items="${errorMessages}" var="message"> 
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/configuration/statutes/search.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/configuration/statutes/search.jsp
@@ -30,7 +30,7 @@
 	<div class="alert alert-info" role="alert">
 
 		<c:forEach items="${infoMessages}" var="message">
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/configuration/statutes/update.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/configuration/statutes/update.jsp
@@ -32,7 +32,7 @@ ${portal.toolkit()}
 	<div class="alert alert-danger" role="alert">
 
 		<c:forEach items="${errorMessages}" var="message">
-			<p>${message}</p>
+			<p><c:out value="${message}" /></p>
 		</c:forEach>
 
 	</div>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/program-conclusion/create.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/program-conclusion/create.jsp
@@ -42,28 +42,28 @@ ${portal.toolkit()}
 		<div class="form-group">
 			<label for="name" class="col-sm-1 control-label"><spring:message code="label.name" /></label>
 			<div class="col-sm-11">
-				<input id="name" name="name" bennu-localized-string class="form-control col-sm-11" required value='${programConclusion.name.json()}' />
+				<input id="name" name="name" bennu-localized-string class="form-control col-sm-11" required value='<c:out value="${programConclusion.name.json()}"/>' />
 			</div>
 		</div>
 		
 		<div class="form-group">
 			<label for="description" class="col-sm-1 control-label"><spring:message code="label.description" /></label>
 			<div class="col-sm-11">
-				<input id="description" name="description" bennu-localized-string class="form-control col-sm-11" value='${programConclusion.description.json()}' />
+				<input id="description" name="description" bennu-localized-string class="form-control col-sm-11" value='<c:out value="${programConclusion.description.json()}"/>' />
 			</div>
 		</div>
 		
 		<div class="form-group">
 			<label for="graduationTitle" class="col-sm-1 control-label"><spring:message code="program.conclusion.graduation.title" /></label>
 			<div class="col-sm-11">
-				<input name="graduationTitle" bennu-localized-string class="form-control col-sm-11" value='${programConclusion.graduationTitle.json()}' />
+				<input name="graduationTitle" bennu-localized-string class="form-control col-sm-11" value='<c:out value="${programConclusion.graduationTitle.json()}"/>' />
 			</div>
 		</div>
 		
 		<div class="form-group">
 			<label for="graduationLevel" class="col-sm-1 control-label"><spring:message code="program.conclusion.graduation.level" /></label>
 			<div class="col-sm-11">
-				<input name="graduationLevel" bennu-localized-string class="form-control col-sm-11" value='${programConclusion.graduationLevel.json()}' />
+				<input name="graduationLevel" bennu-localized-string class="form-control col-sm-11" value='<c:out value="${programConclusion.graduationLevel.json()}"/>' />
 			</div>
 		</div>
 		

--- a/src/main/webapp/WEB-INF/fenixedu-academic/public/showThesis.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/public/showThesis.jsp
@@ -51,7 +51,7 @@
 				<div class="row">
 					<label class="col-sm-2 text-right">${fr:message('resources.ApplicationResources', 'student')}</label>
 					<div class="col-sm-10">
-						${thesis.student.person.name} (${thesis.student.person.username})
+						<c:out value="${thesis.student.person.name} (${thesis.student.person.username})"/>
 					</div>
 				</div>
 				<div class="row">
@@ -63,19 +63,19 @@
 				<div class="row">
 					<label class="col-sm-2 text-right">${fr:message('resources.ApplicationResources', 'label.thesis.fullTitle')}</label>
 					<div class="col-sm-10">
-						<strong>${thesis.finalFullTitle.content}</strong>
+						<strong><c:out value="${thesis.finalFullTitle.content}" /></strong>
 					</div>
 				</div>
 				<div class="row">
 					<label class="col-sm-2 text-right">${fr:message('resources.ApplicationResources', 'label.thesis.abstract')}</label>
 					<div class="col-sm-10" id="abstract">
-						${thesis.thesisAbstract.content}
+						<c:out value="${thesis.thesisAbstract.content}" />
 					</div>
 				</div>
 				<div class="row">
 					<label class="col-sm-2 text-right">${fr:message('resources.ApplicationResources', 'label.thesis.keywords')}</label>
 					<div class="col-sm-10">
-						${thesis.keywords}
+						<c:out value="${thesis.keywords}" />
 					</div>
 				</div>
 			</div>
@@ -98,19 +98,19 @@
 						<div class="row">
 							<label class="col-sm-2 text-right">${fr:message('resources.ApplicationResources', 'label.person.name')}</label>
 							<div class="col-sm-10">
-								${advisor.person.name}
+								<c:out value="${advisor.person.name}" />
 							</div>
 						</div>
 						<div class="row">
 							<label class="col-sm-2 text-right">${fr:message('resources.ApplicationResources', 'label.teacher.category')}</label>
 							<div class="col-sm-10">
-								${advisor.category}
+								<c:out value="${advisor.category}" />
 							</div>
 						</div>
 						<div class="row">
 							<label class="col-sm-2 text-right">${fr:message('resources.ApplicationResources', 'label.coordinator.thesis.edit.teacher.department')}</label>
 							<div class="col-sm-10">
-								${advisor.affiliation}
+								<c:out value="${advisor.affiliation}" />
 							</div>
 						</div>
 					</div>
@@ -119,7 +119,7 @@
 
 			<h4>${fr:message('resources.ApplicationResources', 'title.thesis.details.publication')}</h4>
 			<c:if test="${thesis.evaluated}">
-				${thesis.finalTitle}, ${thesis.student.name}, ${thesis.discussed.year}
+				<c:out value="${thesis.finalTitle}, ${thesis.student.name}, ${thesis.discussed.year}"/>
 				<p>
 					(<a href="${thesis.extendedAbstract.downloadUrl}">
 						<img src="${pageContext.request.contextPath}/images/icon_pdf.gif"/>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/categories/create.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/categories/create.jsp
@@ -36,7 +36,7 @@ ${portal.toolkit()}
 <section>
 	<c:if test="${not empty error}">
 		<div class="alert alert-danger">
-			${error}
+			<c:out value="${error}" />
 		</div>
 	</c:if>
 
@@ -45,14 +45,14 @@ ${portal.toolkit()}
 		<div class="form-group">
 			<label for="code" class="col-sm-1 control-label"><spring:message code="teacher.categories.code" /></label>
 			<div class="col-sm-11">
-				<input class="form-control" name="code" id="code" value="${form.code}" required/>
+				<input class="form-control" name="code" id="code" value="<c:out value='${form.code}'/>" required/>
 			</div>
 		</div>
 
 		<div class="form-group">
 			<label for="name" class="col-sm-1 control-label"><spring:message code="teacher.categories.name" /></label>
 			<div class="col-sm-11">
-				<input type="text" class="form-control" bennu-localized-string name="name" id="name" value='${form.name.json()}' required-any/>
+				<input type="text" class="form-control" bennu-localized-string name="name" id="name" value='<c:out value="${form.name.json()}"/>' required-any/>
 			</div>
 		</div>
 

--- a/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/categories/show.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/categories/show.jsp
@@ -59,9 +59,9 @@ ${portal.toolkit()}
 		<tbody>
 			<c:forEach var="category" items="${categories}">
 				<tr>
-					<td>${category.code}</td>
-					<td>${category.name.content}</td>
-					<td>${category.weight}</td>
+					<td><c:out value="${category.code}"/></td>
+					<td><c:out value="${category.name.content}"/></td>
+					<td><c:out value="${category.weight}"/></td>
 					<td><a class="btn btn-default" href="${editUrl}/${category.externalId}"><spring:message code="label.edit"/></a></td>
 				</tr>
 			</c:forEach>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/revoked.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/revoked.jsp
@@ -74,8 +74,8 @@ text-align: center;
 			<c:forEach var="auth" items="${authorizations}">
 				<c:set var="user" value="${auth.teacher.person.user}"/>
 				<tr>
-					<td>${user.username}</td>
-					<td>${user.name}</td>
+					<td><c:out value="${user.username}"/></td>
+					<td><c:out value="${user.name}"/></td>
 					<td title="${auth.creationDate.toString('dd/MM/yyyy HH:mm:ss')}">
 						${auth.creationDate == null ? '-' : auth.creationDate.toString('dd/MM/yyyy')}
 					</td>
@@ -92,18 +92,18 @@ text-align: center;
 							</c:otherwise>
 						</c:choose>
 					</td>
-					<td>${auth.department.nameI18n.content}</td>
-					<td>${auth.executionSemester.qualifiedName}</td>
-					<td>${auth.teacherCategory.name.content}</td>
+					<td><c:out value="${auth.department.nameI18n.content}"/></td>
+					<td><c:out value="${auth.executionSemester.qualifiedName}"/></td>
+					<td><c:out value="${auth.teacherCategory.name.content}"/></td>
 					<td>${auth.lessonHours}</td>
 					<c:if test="${not empty auth.authorizer}">
-						<td>${auth.authorizer.profile.displayName} (${auth.authorizer.username})</td>
+						<td><c:out value="${auth.authorizer.profile.displayName} (${auth.authorizer.username})"/></td>
 					</c:if>
 					<c:if test="${empty auth.authorizer}">
 						<td>-</td>
 					</c:if>
 					<c:if test="${not empty auth.revoker}">
-						<td>${auth.revoker.profile.displayName} (${auth.revoker.username})</td>
+						<td><c:out value="${auth.revoker.profile.displayName} (${auth.revoker.username})"/></td>
 					</c:if>
 					<c:if test="${empty auth.revoker}">
 						<td>-</td>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/show.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/show.jsp
@@ -162,8 +162,8 @@ $(document).ready(function() {
 					<c:forEach var="auth" items="${authorizations}">
 						<c:set var="user" value="${auth.teacher.person.user}"/>
 						<tr>
-							<td>${user.username}</td>  
-							<td>${user.name}</td>
+							<td><c:out value="${user.username}"/></td>  
+							<td><c:out value="${user.name}"/></td>
 							<td>
 								<c:choose>
 									<c:when test="${auth.contracted}">
@@ -175,11 +175,11 @@ $(document).ready(function() {
 								</c:choose>
 							</td>
 							<c:if test="${empty search.department}">
-								<td>${auth.department.nameI18n.content}</td>
+								<td><c:out value="${auth.department.nameI18n.content}"/></td>
 							</c:if>
-							<td>${auth.teacherCategory.name.content}</td>
+							<td><c:out value="${auth.teacherCategory.name.content}"/></td>
 							<td>${auth.lessonHours}</td>
-							<td>${auth.authorizer.name} (${auth.authorizer.username})</td>
+							<td><c:out value="${auth.authorizer.name} (${auth.authorizer.username})"/></td>
 							<td title="${auth.creationDate.toString('dd/MM/yyyy HH:mm:ss')}">
 								${auth.creationDate == null ? '-' : auth.creationDate.toString('dd/MM/yyyy')}
 							</td>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/upload-finished.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/upload-finished.jsp
@@ -37,7 +37,7 @@
 	<hr />
 	<c:if test="${not empty error}">
 		<div class="alert alert-danger">
-			${error}
+			<c:out value="${error}"/>
 		</div>
 	</c:if>
 	
@@ -61,8 +61,8 @@
 					<c:forEach var="auth" items="${authorizations}">
 						<c:set var="user" value="${auth.teacher.person.user}"/>
 						<tr>
-							<td>${user.username}</td>  
-							<td>${user.name}</td>
+							<td><c:out value="${user.username}"/></td>  
+							<td><c:out value="${user.name}"/></td>
 							<td>
 								<c:choose>
 									<c:when test="${auth.contracted}">
@@ -73,11 +73,11 @@
 									</c:otherwise>
 								</c:choose>
 							</td>
-							<td>${auth.department.nameI18n.content}</td>
-							<td>${auth.executionSemester.qualifiedName}</td>
-							<td>${auth.teacherCategory.name.content}</td>
+							<td><c:out value="${auth.department.nameI18n.content}"/></td>
+							<td><c:out value="${auth.executionSemester.qualifiedName}"/></td>
+							<td><c:out value="${auth.teacherCategory.name.content}"/></td>
 							<td>${auth.lessonHours}</td>
-							<td>${auth.authorizer.name} (${auth.authorizer.username})</td>
+							<td><c:out value="${auth.authorizer.name} (${auth.authorizer.username})"/></td>
 						</tr>
 					</c:forEach>
 				</tbody>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/upload.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/teacher/authorization/upload.jsp
@@ -66,7 +66,7 @@
 				</i>
 				<ul>
 					<c:forEach var="category" items="${categories}">
-						<li>${category.name.content} - ${category.code}</li>
+						<li><c:out value="${category.name.content} - ${category.code}"/></li>
 					</c:forEach>
 				</ul>
 			</li>
@@ -78,7 +78,7 @@
 				</i>
 				<ul>
 					<c:forEach var="department" items="${departments}">
-						<li>${department.acronym} - ${department.nameI18n.content}</li>
+						<li><c:out value="${department.acronym} - ${department.nameI18n.content}"/></li>
 					</c:forEach>
 				</ul>
 			</li>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/teacher/professorship/create.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/teacher/professorship/create.jsp
@@ -117,11 +117,11 @@
 					</tr>
     				<tr>
 						<th class="row"><spring:message code="label.name"/></th>
-						<td>${authorization.teacher.person.user.profile.displayName}</td>
+						<td><c:out value="${authorization.teacher.person.user.profile.displayName}" /></td>
 					</tr>
 					<tr>
 						<th class="row"><spring:message code="label.username"/></th>
-						<td>${authorization.teacher.person.user.username}</td>
+						<td><c:out value="${authorization.teacher.person.user.username}" /></td>
 					</tr>
     			</tbody>
     		</table>
@@ -155,9 +155,9 @@
 					<c:if test="${not empty professorships}">
 						<c:forEach var="professorship" items="${professorships}">
 						<tr data-professorship="${professorship.externalId}" data-responsible="${professorship.responsibleFor}">
-							<td>${professorship.executionCourse.nameI18N.content}</td>
+							<td><c:out value="${professorship.executionCourse.nameI18N.content}" /></td>
 							<td>
-								${professorshipService.getDegreeAcronyms(professorship, ",")}
+								<c:out value="${professorshipService.getDegreeAcronyms(professorship, ',')}" />
 							</td>
 							<td>
 								<div class="btn-group btn-group-xs">
@@ -181,7 +181,7 @@
 	
 	<c:if test="${not empty error}">
 		<div class="alert alert-danger">
-			${error}
+			<c:out value="${error}" />
 		</div>
 		<hr />
 	</c:if>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/teacher/professorship/show.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/teacher/professorship/show.jsp
@@ -206,9 +206,9 @@ $(document).ready(function() {
 						<c:set var="user" value="${auth.teacher.person.user}"/>
 						<c:set var="professorships" value="${professorshipService.getProfessorships(user, search.period)}"/>
 						<tr class="authorization" id="authorization-${auth.externalId}">
-							<td><img src="${user.profile.avatarUrl}" alt="${user.name}" /></td>
-							<td>${user.username}</td>  
-							<td>${user.name}</td>
+							<td><img src="${user.profile.avatarUrl}" alt="<c:out value='${user.name}'/>" /></td>
+							<td><c:out value="${user.username}" /></td>  
+							<td><c:out value="${user.name}" /></td>
 							<td>${professorships.size()}</td>
 							<td><button class="btn btn-default show-courses"><i class="glyphicon glyphicon-collapse-down courses-icon"></i><spring:message code="label.courses"/></button></td>
 						</tr>
@@ -233,9 +233,9 @@ $(document).ready(function() {
 										<c:if test="${not empty professorships }">
 											<c:forEach var="professorship" items="${professorships}">
 											<tr data-professorship="${professorship.externalId}" data-responsible="${professorship.responsibleFor}">
-												<td>${professorship.executionCourse.nameI18N.content}</td>
+												<td><c:out value="${professorship.executionCourse.nameI18N.content}" /></td>
 												<td>
-													${professorshipService.getDegreeAcronyms(professorship, ",")}
+													<c:out value="${professorshipService.getDegreeAcronyms(professorship, ',')}" />
 												</td>
 												<td>
 													<div class="btn-group btn-group-xs">

--- a/src/main/webapp/academicAdminOffice/payments/exemptions/showForAcademicEvent.jsp
+++ b/src/main/webapp/academicAdminOffice/payments/exemptions/showForAcademicEvent.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <html:xhtml />
 
 <h2><bean:message bundle="ACADEMIC_OFFICE_RESOURCES" key="label.payments.exemptions" /></h2>
@@ -44,7 +45,7 @@
 </fr:view>
 
 <h3>
-	${event.description}
+	<c:out value="${event.description}"/>
 </h3>
 
 <bean:define id="personId" name="person" property="externalId" />

--- a/src/main/webapp/academicAdminOffice/payments/exemptions/showForAdministrativeOfficeFeeAndInsuranceEvent.jsp
+++ b/src/main/webapp/academicAdminOffice/payments/exemptions/showForAdministrativeOfficeFeeAndInsuranceEvent.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <html:xhtml />
 
 <h2><bean:message bundle="ACADEMIC_OFFICE_RESOURCES" key="label.payments.exemptions" /></h2>
@@ -44,7 +45,7 @@
 </fr:view>
 
 <h3>
-	${event.description}
+	<c:out value="${event.description}"/>
 </h3>
 
 <bean:define id="personId" name="person" property="externalId" />

--- a/src/main/webapp/academicAdminOffice/payments/exemptions/showForGratuityEvent.jsp
+++ b/src/main/webapp/academicAdminOffice/payments/exemptions/showForGratuityEvent.jsp
@@ -24,6 +24,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <h2><bean:message bundle="ACADEMIC_OFFICE_RESOURCES" key="label.payments.exemptions" /></h2>
 
@@ -44,7 +45,7 @@
 </fr:view>
 
 <h3>	
-	${event.description}
+	<c:out value="${event.description}" />
 </h3>
 
 

--- a/src/main/webapp/academicAdminOffice/payments/exemptions/showForImprovementOfApprovedEnrolmentEvent.jsp
+++ b/src/main/webapp/academicAdminOffice/payments/exemptions/showForImprovementOfApprovedEnrolmentEvent.jsp
@@ -24,6 +24,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <h2><bean:message bundle="ACADEMIC_OFFICE_RESOURCES" key="label.payments.exemptions" /></h2>
 
@@ -44,7 +45,7 @@
 </fr:view>
 
 <h3>
-	${event.description}
+	<c:out value="${event.description}" />
 </h3>
 
 <bean:define id="personId" name="person" property="externalId" />

--- a/src/main/webapp/academicAdminOffice/payments/exemptions/showForInsuranceEvent.jsp
+++ b/src/main/webapp/academicAdminOffice/payments/exemptions/showForInsuranceEvent.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <html:xhtml />
 
 <h2><bean:message bundle="ACADEMIC_OFFICE_RESOURCES" key="label.payments.exemptions" /></h2>
@@ -44,7 +45,7 @@
 </fr:view>
 
 <h3>
-	${event.description}
+	<c:out value="${event.description}" />
 </h3>
 
 <bean:define id="personId" name="person" property="externalId" />

--- a/src/main/webapp/academicAdminOffice/payments/exemptions/showForSecondCycleIndividualCandidacyEvent.jsp
+++ b/src/main/webapp/academicAdminOffice/payments/exemptions/showForSecondCycleIndividualCandidacyEvent.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <html:xhtml />
 
 <h2><bean:message bundle="ACADEMIC_OFFICE_RESOURCES" key="label.payments.exemptions" /></h2>
@@ -44,7 +45,7 @@
 </fr:view>
 
 <h3>
-	${event.description}
+	<c:out value="${event.description}" />
 </h3>
 
 <bean:define id="personId" name="person" property="externalId" />

--- a/src/main/webapp/commons/student/timeTable/classTimeTable.jsp
+++ b/src/main/webapp/commons/student/timeTable/classTimeTable.jsp
@@ -26,6 +26,7 @@
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
 <%@ page import="org.fenixedu.academic.servlet.taglib.sop.v3.TimeTableType" %>
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <html:html xhtml="true">
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -36,9 +37,9 @@
 	<body>
 		<logic:present name="LOGGED_USER_ATTRIBUTE">
 			<p>
-				<p><strong><bean:message  key="label.name" bundle="APPLICATION_RESOURCES"/></strong>: ${person.name}</p>
-				<p><strong><bean:message  key="label.studentNumber" bundle="APPLICATION_RESOURCES"/> </strong>: ${person.student.number} </p>
-				<p><strong><bean:message  key="label.username"  bundle="APPLICATION_RESOURCES"/> </strong>: ${person.username} </p>
+				<p><strong><bean:message  key="label.name" bundle="APPLICATION_RESOURCES"/></strong>: <c:out value="${person.name}" /></p>
+				<p><strong><bean:message  key="label.studentNumber" bundle="APPLICATION_RESOURCES"/> </strong>: <c:out value="${person.student.number}" /> </p>
+				<p><strong><bean:message  key="label.username"  bundle="APPLICATION_RESOURCES"/> </strong>: <c:out value="${person.username}" /> </p>
 			</p>
 		</logic:present>
 		

--- a/src/main/webapp/coordinator/chooseDegreePage.jsp
+++ b/src/main/webapp/coordinator/chooseDegreePage.jsp
@@ -45,7 +45,7 @@
 				</logic:empty>
 		   </td>
 		   <td class="acenter">
-				<a href="${pageContext.request.contextPath}/coordinator/coordinatorIndex.do?degreeCurricularPlanID=${degreeCurricularPlan.externalId}">${degreeCurricularPlan.name}</a>
+				<a href="${pageContext.request.contextPath}/coordinator/coordinatorIndex.do?degreeCurricularPlanID=${degreeCurricularPlan.externalId}"><c:out value="${degreeCurricularPlan.name}" /></a>
 		   </td>	   
 		</tr>
 	</logic:iterate>

--- a/src/main/webapp/departmentMember/chooseUnit.jsp
+++ b/src/main/webapp/departmentMember/chooseUnit.jsp
@@ -26,6 +26,6 @@
 
 <ul>
 	<c:forEach var="unit" items="${units}">
-		<blockquote><a href="?unitId=${unit.externalId}">${unit.name} (${unit.acronym})</a></blockquote>
+		<blockquote><a href="?unitId=${unit.externalId}"><c:out value="${unit.name} (${unit.acronym})"/></a></blockquote>
 	</c:forEach>
 </ul>

--- a/src/main/webapp/manager/listAssociatedObjects.jsp
+++ b/src/main/webapp/manager/listAssociatedObjects.jsp
@@ -27,6 +27,7 @@
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/taglib/enum" prefix="e" %>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr" %>
 <%@ taglib prefix="if" uri="http://jakarta.apache.org/struts/tags-logic" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <html:xhtml/>
 
@@ -35,7 +36,7 @@
 <h3>Degree Types</h3>
 <ul>
     <logic:iterate id="type" name="degreeTypes">
-        <li>${type.name.content} - <html:link page="/manageAssociatedObjects.do?method=prepareCreateDegreeType&degreeTypeId=${type.externalId}">Edit</html:link><br/>
+        <li><c:out value="${type.name.content}"/> - <html:link page="/manageAssociatedObjects.do?method=prepareCreateDegreeType&degreeTypeId=${type.externalId}">Edit</html:link><br/>
 </li>
     </logic:iterate>
 </ul>

--- a/src/main/webapp/notFound.jsp
+++ b/src/main/webapp/notFound.jsp
@@ -80,5 +80,5 @@ response.setStatus(404);
 			</c:if>
 		</div>
 	</div>
-	<!-- Message: '${pageContext.findAttribute('javax.servlet.error.message')}' -->
+	<!-- Message: '<c:out value="${pageContext.findAttribute('javax.servlet.error.message')}" />' -->
 </body>

--- a/src/main/webapp/phd/academicAdminOffice/payments/exemptions/showForPhdEvent.jsp
+++ b/src/main/webapp/phd/academicAdminOffice/payments/exemptions/showForPhdEvent.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <html:xhtml />
 
 	<em><bean:message key="label.payments" bundle="ACADEMIC_OFFICE_RESOURCES"/></em>
@@ -45,7 +46,7 @@
 	</fr:view>
 	
 	<h3>
-		${event.description}
+		<c:out value="${event.description}" />
 	</h3>
 
 	<bean:define id="personId" name="person" property="externalId" />

--- a/src/main/webapp/phd/academicAdminOffice/payments/exemptions/showForPhdRegistrationFee.jsp
+++ b/src/main/webapp/phd/academicAdminOffice/payments/exemptions/showForPhdRegistrationFee.jsp
@@ -24,6 +24,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 	<em><bean:message key="label.payments" bundle="ACADEMIC_OFFICE_RESOURCES"/></em>
 	<h2><bean:message bundle="ACADEMIC_OFFICE_RESOURCES" key="label.payments.exemptions" /></h2>
@@ -45,7 +46,7 @@
 	</fr:view>
 	
 	<h3>
-		${event.description}
+		<c:out value="${event.description}" />
 	</h3>
 
 	<bean:define id="personId" name="person" property="externalId" />

--- a/src/main/webapp/phd/academicAdminOffice/payments/exemptions/showPhdGratuity.jsp
+++ b/src/main/webapp/phd/academicAdminOffice/payments/exemptions/showPhdGratuity.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <html:xhtml />
 
 	<em><bean:message key="label.payments" bundle="ACADEMIC_OFFICE_RESOURCES"/></em>
@@ -45,7 +46,7 @@
 	</fr:view>
 	
 	<h3>
-		${event.description}
+		<c:out value="${event.description}" />
 	</h3>
 
 	<bean:define id="personId" name="person" property="externalId" />

--- a/src/main/webapp/residenceManagement/residenceRoleManagement.jsp
+++ b/src/main/webapp/residenceManagement/residenceRoleManagement.jsp
@@ -48,8 +48,8 @@
 	<tbody>
 		<c:forEach items="${role.members}" var="member">
 			<tr>
-				<td>${member.name}</td>
-				<td>${member.username}</td>
+				<td><c:out value="${member.name}" /></td>
+				<td><c:out value="${member.username}" /></td>
 				<td><a href="${pageContext.request.contextPath}/residenceManagement/residenceRoleManagement.do?method=removeResidenceRoleManagemenToPerson&userToRemove=${member.username}">${portal.message('resources.ApplicationResources', 'label.remove')}</a></td>
 			</tr>
 		</c:forEach>

--- a/src/main/webapp/resourceAllocationManager/manageClass_bd.jsp
+++ b/src/main/webapp/resourceAllocationManager/manageClass_bd.jsp
@@ -25,13 +25,14 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/datetime-1.0" prefix="dt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ page import="java.util.List"%>
 
 <jsp:include page="/commons/contextClassAndExecutionDegreeAndCurricularYear.jsp" />
 
-<h2><bean:message key="link.manage.turmas"/> <span class="small">${executionDegree.executionDegree.degreeCurricularPlan.name}</span></h2>
+<h2><bean:message key="link.manage.turmas"/> <span class="small"><c:out value="${executionDegree.executionDegree.degreeCurricularPlan.name}" /></span></h2>
 
-<h3>Manipular Turma <span class="small">${schoolClass.nome}</span></h3>
+<h3>Manipular Turma <span class="small"><c:out value="${schoolClass.nome}" /></span></h3>
 
 
 <html:link styleClass="btn btn-primary btn-sm" page="/manageClass.do?method=prepareAddShifts&academicInterval=${academicInterval}&execution_degree_oid=${execution_degree_oid}&curricular_year_oid=${curricularYearOID}&class_oid=${classOID}">

--- a/src/main/webapp/resourceAllocationManager/manageClasses_bd.jsp
+++ b/src/main/webapp/resourceAllocationManager/manageClasses_bd.jsp
@@ -24,10 +24,11 @@
 <html:xhtml/>
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <jsp:include page="/commons/contextExecutionDegreeAndCurricularYear.jsp"/>
 
-<h2>Manipular Turmas <span class="small">${context_selection_bean.executionDegree.degreeCurricularPlan.name} - ${context_selection_bean.curricularYear.year}º ano (${context_selection_bean.academicInterval.pathName})</span></h2>
+<h2>Manipular Turmas <span class="small"><c:out value="${context_selection_bean.executionDegree.degreeCurricularPlan.name} - ${context_selection_bean.curricularYear.year}º ano (${context_selection_bean.academicInterval.pathName})" /></span></h2>
 
 <jsp:include page="context.jsp" />
 

--- a/src/main/webapp/resourceAllocationManager/manageSchedules_bd.jsp
+++ b/src/main/webapp/resourceAllocationManager/manageSchedules_bd.jsp
@@ -24,11 +24,12 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<h2><bean:message key="title.manage.schedule"/> <span class="small">${context_selection_bean.academicInterval.pathName}</span></h2>
+<h2><bean:message key="title.manage.schedule"/> <span class="small"><c:out value="${context_selection_bean.academicInterval.pathName}" /></span></h2>
 
 
-<h4>${context_selection_bean.executionDegree.presentationName} <span class="small">${context_selection_bean.curricularYear.year}º ano</span></h4>
+<h4><c:out value="${context_selection_bean.executionDegree.presentationName}" /> <span class="small"><c:out value="${context_selection_bean.curricularYear.year}º ano" /></span></h4>
 
 <fr:form action="/chooseContext.do">
 	<fr:edit name="context_selection_bean" schema="degreeContext.choose">

--- a/src/main/webapp/resourceAllocationManager/manageShift_bd.jsp
+++ b/src/main/webapp/resourceAllocationManager/manageShift_bd.jsp
@@ -23,14 +23,15 @@
 <%@ taglib uri="http://struts.apache.org/tags-html" prefix="html" %>
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/datetime-1.0" prefix="dt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@page import="org.fenixedu.academic.ui.struts.action.resourceAllocationManager.utils.PresentationConstants"%>
 <html:xhtml/>
 
 <jsp:include page="/commons/contextShiftAndExecutionCourseAndExecutionDegreeAndCurricularYear.jsp" />
 
-<h2><bean:message key="link.manage.turnos"/> <span class="small">${executionDegree.executionDegree.degreeCurricularPlan.name}</span></h2>
+<h2><bean:message key="link.manage.turnos"/> <span class="small"><c:out value="${executionDegree.executionDegree.degreeCurricularPlan.name}" /></span></h2>
 
-<h3><bean:message key="title.editTurno"/> <span class="small">${shift.nome}</span></h3>
+<h3><bean:message key="title.editTurno"/> <span class="small"><c:out value="${shift.nome}" /></span></h3>
 
 <p>
 	<span class="error"><!-- Error messages go here -->

--- a/src/main/webapp/resourceAllocationManager/manageShifts_bd.jsp
+++ b/src/main/webapp/resourceAllocationManager/manageShifts_bd.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/datetime-1.0" prefix="dt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ page import="org.fenixedu.academic.ui.struts.action.resourceAllocationManager.utils.PresentationConstants" %>
 <%@ page import="java.util.List"%>
 <html:xhtml/>
@@ -30,7 +31,7 @@
 <jsp:include page="/commons/contextExecutionCourseAndExecutionDegreeAndCurricularYear.jsp" />
 
 <h2><bean:message key="link.manage.turnos"/> 
-	<span class="small">${context_selection_bean.executionDegree.degreeCurricularPlan.name} - ${context_selection_bean.curricularYear.year}º ano (${context_selection_bean.academicInterval.pathName})</span></h2>
+	<span class="small"><c:out value="${context_selection_bean.executionDegree.degreeCurricularPlan.name} - ${context_selection_bean.curricularYear.year}º ano (${context_selection_bean.academicInterval.pathName})" /></span></h2>
 
 <jsp:include page="context.jsp"/>
 

--- a/src/main/webapp/resourceAllocationManager/viewAllClassesSchedules.jsp
+++ b/src/main/webapp/resourceAllocationManager/viewAllClassesSchedules.jsp
@@ -33,10 +33,10 @@
 		<c:if test="${schoolClass.academicInterval == academicInterval}">
 			<div class="single">
 			<div class="alert alert-warning">
-				${degree.presentationName} - ${academicInterval.pathName}
+				<c:out value="${degree.presentationName} - ${academicInterval.pathName}" />
 			</div>
 			<div>
-				<h4><bean:message key="title.class.timetable" />${schoolClass.nome}</h4>
+				<h4><bean:message key="title.class.timetable" /><c:out value="${schoolClass.nome}" /></h4>
 				<% request.setAttribute("lessons", InfoLesson.newInfosForSchoolClass((SchoolClass) pageContext.findAttribute("schoolClass"))); %>
 				<app:gerarHorario name="lessons" definedWidth="false" type="<%= TimeTableType.CLASS_TIMETABLE_WITHOUT_LINKS %>"/>
 			</div>

--- a/src/main/webapp/resourceAllocationManager/viewAllRoomsSchedules.jsp
+++ b/src/main/webapp/resourceAllocationManager/viewAllRoomsSchedules.jsp
@@ -29,7 +29,7 @@
 <c:forEach var="bean" items="${beans}">
 	<div class="single">
 	<div class="alert alert-warning">
-		<strong>${academicInterval.pathName}</strong>
+		<strong><c:out value="${academicInterval.pathName}" /></strong>
 	</div>
 
 	<table class="table table-bordered">
@@ -55,19 +55,19 @@
 		</thead>
 		<tr>
 			<td class="listClasses">
-				${bean.room.name}
+				<c:out value="${bean.room.name}" />
 			</td>
 			<td class="listClasses">
-				${bean.room.classification.name.content}
+				<c:out value="${bean.room.classification.name.content}" />
 			</td>
 			<td class="listClasses">
-				${bean.room.parent.name}
+				<c:out value="${bean.room.parent.name}" />
 			</td>
 			<td class="listClasses">
 				x
 			</td>
 			<td class="listClasses">
-				${bean.room.allocatableCapacity}
+				<c:out value="${bean.room.allocatableCapacity}" />
 			</td>
 			<td class="listClasses">
 				y

--- a/src/main/webapp/resourceAllocationManager/viewClassSchedule_bd.jsp
+++ b/src/main/webapp/resourceAllocationManager/viewClassSchedule_bd.jsp
@@ -27,14 +27,15 @@
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/datetime-1.0" prefix="dt" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/struts-example-1.0" prefix="app" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <link href="<%= request.getContextPath() %>/CSS/dotist_timetables.css" rel="stylesheet" type="text/css" />
 
 <jsp:include page="/commons/contextClassAndExecutionDegreeAndCurricularYear.jsp" />
 
-<h2><bean:message key="link.manage.turmas"/> <span class="small">${executionDegree.executionDegree.degreeCurricularPlan.name}</span></h2>
+<h2><bean:message key="link.manage.turmas"/> <span class="small"><c:out value="${executionDegree.executionDegree.degreeCurricularPlan.name}" /></span></h2>
 
-<h3>Manipular Turma <span class="small">${className}</span></h3>
+<h3>Manipular Turma <span class="small"><c:out value="${className}" /></span></h3>
 
 
 <html:link styleClass="btn btn-primary btn-sm" page="/manageClass.do?method=prepareAddShifts&academicInterval=${academicInterval}&execution_degree_oid=${execution_degree_oid}&curricular_year_oid=${curricularYearOID}&class_oid=${classOID}">

--- a/src/main/webapp/resourceAllocationManager/viewStudentsEnroledInShift_bd.jsp
+++ b/src/main/webapp/resourceAllocationManager/viewStudentsEnroledInShift_bd.jsp
@@ -25,10 +25,11 @@
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic" %>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <%@ taglib uri="http://jakarta.apache.org/taglibs/datetime-1.0" prefix="dt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <jsp:include page="/commons/contextShiftAndExecutionCourseAndExecutionDegreeAndCurricularYear.jsp" />
 
-<h2><bean:message key="link.manage.turnos"/> <span class="small">${executionDegree.executionDegree.degreeCurricularPlan.name}</span></h2>
+<h2><bean:message key="link.manage.turnos"/> <span class="small"><c:out value="${executionDegree.executionDegree.degreeCurricularPlan.name}" /></span></h2>
 
 <bean:define id="shiftName" name="<%= PresentationConstants.SHIFT %>" property="nome"/>
 <bean:define id="shiftId" name="<%= PresentationConstants.SHIFT %>" property="externalId"/>
@@ -38,7 +39,7 @@
 	<bean:message key="button.back" />
 </html:link>
 
-<h3>Alunos Inscritos <span class="small">${shift.nome}</span></h3>
+<h3>Alunos Inscritos <span class="small"><c:out value="${shift.nome}" /></span></h3>
 
 <p>
 	<logic:present name="<%= PresentationConstants.EXECUTION_COURSE %>" scope="request">

--- a/src/main/webapp/student/enrollment/bolonha/enrollmentCannotProceed.jsp
+++ b/src/main/webapp/student/enrollment/bolonha/enrollmentCannotProceed.jsp
@@ -26,7 +26,7 @@
 
 <div class="alert alert-danger">
     <html:messages id="messages" message="true" bundle="STUDENT_RESOURCES">
-        ${messages}
+        <c:out value="${messages}" />
     </html:messages>
 </div>
 <c:if test="${start != null}">

--- a/src/main/webapp/student/enrollment/listClasses.jsp
+++ b/src/main/webapp/student/enrollment/listClasses.jsp
@@ -30,7 +30,7 @@
 
 <c:if test="${hasExecutionCourse}">
 	<h6 class="text-center">
-		${executionCourse.name}<br />
+		<c:out value="${executionCourse.name}" /><br />
 		(<html:link page="/studentShiftEnrollmentManagerLookup.do?method=proceedToShiftEnrolment&registrationOID=${registrationOID}">
 			<bean:message bundle="STUDENT_RESOURCES" key="link.student.seeAllClasses" />
 		</html:link>)
@@ -42,13 +42,13 @@
 		<li class="${schoolClass == selectedSchoolClass ? 'active': ''}">
 			<c:if test="${hasExecutionCourse}">
 				<html:link page="/studentShiftEnrollmentManagerLookup.do?method=proceedToShiftEnrolment&registrationOID=${registrationOID}&classId=${schoolClass.externalId}&executionCourseID=${executionCourse.externalId}">
-					<bean:message key="label.class" />&nbsp;${schoolClass.nome}		
+					<bean:message key="label.class" />&nbsp;<c:out value="${schoolClass.nome}" />		
 				</html:link>
 			</c:if>
 			
 			<c:if test="${!hasExecutionCourse}">
 				<html:link page="/studentShiftEnrollmentManagerLookup.do?method=proceedToShiftEnrolment&registrationOID=${registrationOID}&classId=${schoolClass.externalId}">
-					<bean:message key="label.class" />&nbsp;${schoolClass.nome}	
+					<bean:message key="label.class" />&nbsp;<c:out value="${schoolClass.nome}" />	
 				</html:link>
 			</c:if>
 		</li>

--- a/src/main/webapp/teacher/evaluation/evaluationMenu.jsp
+++ b/src/main/webapp/teacher/evaluation/evaluationMenu.jsp
@@ -80,7 +80,7 @@
 	</nav>
 	<main class="col-lg-10">
 		<ol class="breadcrumb">
-			<em>${executionCourse.name} - ${executionCourse.executionPeriod.qualifiedName}
-				(<c:forEach var="degree" items="${executionCourse.degreesSortedByDegreeName}"> ${degree.sigla} </c:forEach>)
+			<em><c:out value="${executionCourse.name} - ${executionCourse.executionPeriod.qualifiedName}" />
+				(<c:forEach var="degree" items="${executionCourse.degreesSortedByDegreeName}"> <c:out value="${degree.sigla}" /> </c:forEach>)
 			</em>
 		</ol>

--- a/src/main/webapp/teacher/executionCourse/attendsSearch/viewStudentList.jsp
+++ b/src/main/webapp/teacher/executionCourse/attendsSearch/viewStudentList.jsp
@@ -38,7 +38,7 @@
 	value="/teacher/${executionCourse.externalId}/student-groups/viewStudentsAndGroupsByShift/${grouping.externalId}/" />
 
 <h2>${fr:message('resources.ApplicationResources', 'message.attendingStudentsOf')}
-	${executionCourse.name}</h2>
+	<c:out value="${executionCourse.name}" /></h2>
 
 <div ng-app="AttendsSearchApp">
 	<div ng-controller="AttendsSearchCtrl">

--- a/src/main/webapp/teacher/executionCourse/executionCourseFrame.jsp
+++ b/src/main/webapp/teacher/executionCourse/executionCourseFrame.jsp
@@ -32,8 +32,8 @@
 <div class="row">
 	<main class="col-sm-10 col-sm-push-2">
 		<ol class="breadcrumb">
-			<em>${executionCourse.name} - ${executionCourse.executionPeriod.qualifiedName}
-				(<c:forEach var="degree" items="${executionCourse.degreesSortedByDegreeName}"> ${degree.sigla} </c:forEach>)
+			<em><c:out value="${executionCourse.name} - ${executionCourse.executionPeriod.qualifiedName}" />
+				(<c:forEach var="degree" items="${executionCourse.degreesSortedByDegreeName}"> <c:out value="${degree.sigla}" /> </c:forEach>)
 			</em>
 		</ol>
 		<jsp:include page="${teacher$actual$page}" />
@@ -41,7 +41,7 @@
 	<nav class="col-sm-2 col-sm-pull-10" id="context" style="background-color: #f1f1f1; padding-bottom: 20px">
 		<ul class="nav nav-pills nav-stacked">
 			<li class="navheader">
-				<strong>${executionCourse.prettyAcronym}</strong>
+				<strong><c:out value="${executionCourse.prettyAcronym}" /></strong>
 			</li>
 			<c:if test="${not empty executionCourse.siteUrl}">
 				<li>

--- a/src/main/webapp/teacher/executionCourse/groupings/insertGroupProperties.jsp
+++ b/src/main/webapp/teacher/executionCourse/groupings/insertGroupProperties.jsp
@@ -232,9 +232,9 @@
 					<c:set var="ocupation" value="${fn:length(shift.studentsSet)}" />
 					<c:set var="type" value="${shift.types }" />
 					<tr class="diferentiatedCapacityShift" data-shiftType="${type}">
-						<td>${ lessons}</td>
-						<td>${ lotacao}</td>
-						<td>${ ocupation}</td>
+						<td><c:out value="${ lessons}" /></td>
+						<td><c:out value="${ lotacao}" /></td>
+						<td><c:out value="${ ocupation}" /></td>
 						<td>
 						<form:input type="number" id="differentiatedCapacityShifts[${id }]"
 							class="form-control" path="differentiatedCapacityShifts[${id }]" /></td>

--- a/src/main/webapp/teacher/executionCourse/groupings/viewAllStudentsAndGroups.jsp
+++ b/src/main/webapp/teacher/executionCourse/groupings/viewAllStudentsAndGroups.jsp
@@ -105,7 +105,7 @@
 								width="100" height="100" /></td>
 
 						</c:if>
-						<td>${student.name}</td>
+						<td><c:out value="${student.name}"/></td>
 						<td><a href="mailto:" ${student.email }> ${student.email}
 						</a></td>
 					</tr>

--- a/src/main/webapp/teacher/executionCourse/groupings/viewAttendsSet.jsp
+++ b/src/main/webapp/teacher/executionCourse/groupings/viewAttendsSet.jsp
@@ -134,7 +134,7 @@
 										<td class="acenter showPhotos hide"><img class="lazy"
 											data-original="${userPhotoBaseLink.concat(attends.registration.person.username)}"
 											width="100" height="100" /></td>
-										<td>${attends.registration.person.name}</td>
+										<td><c:out value="${attends.registration.person.name}" /></td>
 										<td><c:choose>
 												<c:when
 													test="${not empty attends.registration.person.email}">
@@ -203,7 +203,7 @@
 										<td class="acenter showPhotos hide"><img class="lazy"
 											data-original="${userPhotoBaseLink.concat(registration.person.username)}"
 											width="100" height="100" /></td>
-										<td>${registration.person.name}</td>
+										<td><c:out value="${registration.person.name}" /></td>
 										<td><c:if test="${not empty registration.person.email}">
 												<html:link href="mailto:${registration.person.email}">${registration.person.email}</html:link>
 											</c:if> <c:if test="${empty registration.person.email}">

--- a/src/main/webapp/teacher/executionCourse/groupings/viewProjectsAndLink.jsp
+++ b/src/main/webapp/teacher/executionCourse/groupings/viewProjectsAndLink.jsp
@@ -94,7 +94,7 @@
 					<p>${fr:message('resources.ApplicationResources', 'label.projectName')}:
 						<strong> <html:link
 								page="/teacher/${executionCourse.externalId}/student-groups/view/${groupProperties.externalId}">
-								${groupProperties.name}
+								<c:out value="${groupProperties.name}" />
 								</html:link>
 						</strong>
 					</p>
@@ -179,7 +179,7 @@
 						<strong>${fr:message('resources.ApplicationResources', 'label.projectDescription')}:
 						</strong> <span><c:if
 								test="${not empty groupProperties.projectDescription}">
-							${groupProperties.projectDescription}
+							<c:out value="${groupProperties.projectDescription}" />
 						</c:if> <c:if test="${empty groupProperties.projectDescription}">
 							${fr:message('resources.ApplicationResources', 'message.project.wihtout.description')}
 						</c:if></span>
@@ -190,7 +190,7 @@
 							</strong>
 							<c:forEach var="infoExportGrouping"
 								items="${groupProperties.exportGroupingsSet }">
-								${infoExportGrouping.executionCourse.nome}
+								<c:out value="${infoExportGrouping.executionCourse.nome}" />
 
 					</c:forEach>
 						</c:if>

--- a/src/main/webapp/teacher/executionCourse/groupings/viewShiftsAndGroups.jsp
+++ b/src/main/webapp/teacher/executionCourse/groupings/viewShiftsAndGroups.jsp
@@ -167,7 +167,7 @@
 				<c:forEach var="studentGroup" items="${studentGroups}">
 					<a class="btn btn-default pull-left" type="submit"
 						href="${studentGroupBaseLink.concat(studentGroup.externalId)}">
-						${studentGroup.groupNumber } </a>
+						<c:out value="${studentGroup.groupNumber }" /> </a>
 				</c:forEach>
 				<c:if test="${empty studentGroups }">
 					<button class="btn btn-default disabled">${fr:message('resources.ApplicationResources', 'message.shift.without.groups')}</button>
@@ -213,7 +213,7 @@
 										<strong>${fr:message('resources.ApplicationResources', 'property.lesson.room')}</strong>
 										<c:if
 											test="${not empty lesson.roomOccupation and not empty lesson.roomOccupation.room }">
-					               		${ lesson.roomOccupation.room.name}
+					               		<c:out value="${ lesson.roomOccupation.room.name}" />
 					               		</c:if>
 									</p>
 								</div>
@@ -245,7 +245,7 @@
 						items="${studentGroupsByShift[shift]}">
 						<a class="btn btn-default pull-left" type="submit"
 							href="${studentGroupBaseLink.concat(studentGroup.externalId)}">
-							${studentGroup.groupNumber}</a>
+							<c:out value="${studentGroup.groupNumber}" /></a>
 					</c:forEach>
 					<c:if test="${empty studentGroupsByShift[shift] }">
 						<button class="btn btn-default disabled">${fr:message('resources.ApplicationResources', 'message.shift.without.groups')}</button>

--- a/src/main/webapp/teacher/executionCourse/groupings/viewStudentGroupInformation.jsp
+++ b/src/main/webapp/teacher/executionCourse/groupings/viewStudentGroupInformation.jsp
@@ -53,7 +53,7 @@
 
 
 <h2>${fr:message('resources.ApplicationResources', 'title.StudentGroupInformation')}
-	${studentGroup.groupNumber}</h2>
+	<c:out value="${studentGroup.groupNumber}" /></h2>
 <div class="row">
 	<a class="col-md-12" href="${viewShiftsAndGroups}"><span
 		class="glyphicon glyphicon-chevron-left"></span>
@@ -127,7 +127,7 @@
 						<strong>${fr:message('resources.ApplicationResources', 'property.shift')}</strong>
 						<a
 							href="${studentsAndGroupsByShiftLink.concat('shift/').concat(studentGroup.shift.externalId)} ">
-							${studentGroup.shift.nome } </a>
+							<c:out value="${studentGroup.shift.nome }" /> </a>
 						<button class="btn btn-default btn-xs pull-right"
 							data-toggle="modal" data-target="#editShift">
 							<span class="glyphicon glyphicon-edit"></span>
@@ -147,7 +147,7 @@
 									</p>
 									<p>
 										<strong>${fr:message('resources.ApplicationResources', 'property.lesson.room')}</strong>
-										<span>${lesson.roomOccupation.room.name}</span>
+										<span><c:out value="${lesson.roomOccupation.room.name}" /></span>
 									</p>
 									<p>
 										<strong>${fr:message('resources.ApplicationResources', 'property.lesson.beginning')}</strong>
@@ -236,7 +236,7 @@
 								<td class="acenter showPhotos hide"><img class="lazy"
 									data-original="${userPhotoBaseLink.concat(attends.registration.person.username)}"
 									width="100" height="100" /></td>
-								<td>${attends.registration.person.name}</td>
+								<td><c:out value="${attends.registration.person.name}" /></td>
 								<td><c:choose>
 										<c:when test="${not empty attends.registration.person.email}">
 											<html:link href="mailto:${attends.registration.person.email}">${attends.registration.person.email}</html:link>
@@ -296,7 +296,7 @@
 								<td class="acenter showPhotos hide"><img class="lazy"
 									data-original="${userPhotoBaseLink.concat(reg.person.username)}"
 									width="100" height="100" /></td>
-								<td>${attend.registration.person.name}</td>
+								<td><c:out value="${attend.registration.person.name}" /></td>
 								<td><c:if test="${not empty reg.person.email}">
 										<html:link href="mailto:${reg.person.email}">${reg.person.email}</html:link>
 									</c:if> <c:if test="${empty reg.person.email}">

--- a/src/main/webapp/teacher/executionCourse/groupings/viewStudentsAndGroupsByShift.jsp
+++ b/src/main/webapp/teacher/executionCourse/groupings/viewStudentsAndGroupsByShift.jsp
@@ -37,7 +37,7 @@
 
 <c:if test="${not empty shift}">
 	<h2>${fr:message('resources.ApplicationResources', 'title.viewStudentsAndGroupsByShift')}
-		${shift.presentationName }</h2>
+		<c:out value="${shift.presentationName }" /></h2>
 </c:if>
 <c:if test="${empty shift}">
 	<h2>${fr:message('resources.ApplicationResources', 'title.viewStudentsAndGroups')}
@@ -66,7 +66,7 @@
 					<strong>${fr:message('resources.ApplicationResources', 'property.shift')}</strong>
 					<a
 						href="${studentsAndGroupsByShiftLink.concat('shift/').concat(studentGroup.shift.externalId)} ">
-						${studentGroup.shift.nome } </a>
+						<c:out value="${studentGroup.shift.nome }" /> </a>
 					<button class="btn btn-default btn-xs pull-right"
 						data-toggle="modal" data-target="#editShift">
 						<span class="glyphicon glyphicon-edit"></span>
@@ -85,7 +85,7 @@
 							</p>
 							<p>
 								<strong>${fr:message('resources.ApplicationResources', 'property.lesson.room')}</strong>
-								<span>${lesson.roomOccupation.room.name}</span>
+								<span><c:out value="${lesson.roomOccupation.room.name}" /></span>
 							</p>
 							<p>
 								<strong>${fr:message('resources.ApplicationResources', 'property.lesson.end')}</strong>
@@ -156,14 +156,14 @@
 					<tr class="studentRow">
 						<td class="acenter">${student.number}</td>
 						<td class="acenter">${student.person.username}</td>
-						<td class="acenter">${group.groupNumber}</td>
+						<td class="acenter"><c:out value="${group.groupNumber}" /></td>
 						<c:if test="${empty showPhotos}">
 							<td class="acenter showPhotos hide"><img class="lazy"
 								data-original="${userPhotoBaseLink.concat(student.person.username)}"
 								width="100" height="100" /></td>
 
 						</c:if>
-						<td>${student.name}</td>
+						<td><c:out value="${student.name}" /></td>
 						<td><a href="mailto:" ${student.email }> ${student.email}
 						</a></td>
 					</tr>

--- a/src/main/webapp/teacher/listProfessorships.jsp
+++ b/src/main/webapp/teacher/listProfessorships.jsp
@@ -38,7 +38,7 @@
 				<select name="executionPeriodID" onchange="this.form.submit();">
 					<option value=""><bean:message key="option.all.execution.periods"></bean:message></option>
 					<c:forEach items="${semesters}" var="semester">
-						<option value="${semester.externalId}" ${semester == executionPeriod ? 'selected' : ''}>${semester.qualifiedName}</option>
+						<option value="${semester.externalId}" ${semester == executionPeriod ? 'selected' : ''}><c:out value="${semester.qualifiedName}" /></option>
 					</c:forEach>
 				</select>
 			</fr:form>
@@ -69,7 +69,7 @@
 				<td style="width: 450px;">
 					<strong>
 						<html:link page="/manageExecutionCourse.do?method=instructions&executionCourseID=${executionCourse.externalId}">
-							${executionCourse.nome} (${executionCourse.sigla})
+							<c:out value="${executionCourse.nome} (${executionCourse.sigla})" />
 						</html:link>
 					</strong>
 					


### PR DESCRIPTION
As regular EL expressions do not provide any sort of XML escaping, their single use is prone to XSS attacks.

This PR addresses this issue, but wrapping the relevant expressions in `<c:out>` tags, which properly escape their contents.

The changes in this PR have been tested with the JSPC compiler.

Issue: ACDM-790