### PR TITLE
ACDM-690 #comment Return degree description when cycle type is null

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/student/Registration.java
+++ b/src/main/java/org/fenixedu/academic/domain/student/Registration.java
@@ -1666,10 +1666,9 @@ public class Registration extends Registration_Base {
     @Deprecated
     final public String getDegreeDescription(ExecutionYear executionYear, final CycleType cycleType, final Locale locale) {
         CycleCourseGroup cycleCourseGroup = getLastStudentCurricularPlan().getCycleCourseGroup(cycleType);
-        if (cycleCourseGroup != null && cycleCourseGroup.getProgramConclusion() != null) {
-            return getDegreeDescription(executionYear, cycleCourseGroup.getProgramConclusion(), locale);
-        }
-        return "";
+        ProgramConclusion programConclusion = cycleCourseGroup != null ? cycleCourseGroup.getProgramConclusion() : null;
+
+        return getDegreeDescription(executionYear, programConclusion, locale);
     }
 
     public String getDegreeCurricularPlanName() {


### PR DESCRIPTION
The following issue changed the way degree description is given by
registration.
Always return the degree description even if the cycle type is null.

Issue: ACDM-690