### PR TITLE
ACDM-690 #comment Ignore current group when checking for conclusions

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/degreeStructure/CourseGroup.java
+++ b/src/main/java/org/fenixedu/academic/domain/degreeStructure/CourseGroup.java
@@ -305,8 +305,8 @@ public class CourseGroup extends CourseGroup_Base {
             return;
         }
 
-        if (getParentDegreeCurricularPlan().getAllCoursesGroups().stream().map(CourseGroup::getProgramConclusion)
-                .filter(Objects::nonNull).anyMatch(pc -> pc.equals(programConclusion))) {
+        if (getParentDegreeCurricularPlan().getAllCoursesGroups().stream().filter(cg -> !cg.equals(this))
+                .map(CourseGroup::getProgramConclusion).filter(Objects::nonNull).anyMatch(pc -> pc.equals(programConclusion))) {
             throw new DomainException("error.program.conclusion.already.exists", programConclusion.getName().getContent());
         }
     }


### PR DESCRIPTION
When editing course group information the check for duplicate program
conclusion should ignore the current group program conclusion.

Issue: ACDM-690