### PR TITLE
Fixed SearchPerson's active parameter. ACDM-875 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/service/services/person/SearchPerson.java
+++ b/src/main/java/org/fenixedu/academic/service/services/person/SearchPerson.java
@@ -343,7 +343,7 @@ public class SearchPerson implements Serializable {
         }
 
         protected boolean verifyActiveState(Boolean activePersons, Person person) {
-            return (activePersons == null || ((Boolean) RoleType.PERSON.isMember(person.getUser())).equals(activePersons));
+            return (activePersons == null || person.getUser().isLoginExpired() == !activePersons.booleanValue());
         }
 
         protected boolean verifyUsernameEquality(String usernameToSearch, Person person) {


### PR DESCRIPTION
 * Previously worked based on PERSON role, since the roles were refactored the best approach is to question the users's login validity.