### PR TITLE
Do not ignore years when calculating number of months for penalty. #ACDM-877 resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/accounting/installments/InstallmentForFirstTimeStudents.java
+++ b/src/main/java/org/fenixedu/academic/domain/accounting/installments/InstallmentForFirstTimeStudents.java
@@ -105,7 +105,8 @@ public class InstallmentForFirstTimeStudents extends InstallmentForFirstTimeStud
     }
 
     private int getNumberOfMonthsToChargePenalty(final Event event, final DateTime when) {
-        final int numberOfMonths = (new Period(getWhenStartToApplyPenalty(event, when), when.toDateMidnight()).getMonths() + 1);
+        final Period period = new Period(getWhenStartToApplyPenalty(event, when), when.toDateMidnight());
+        final int numberOfMonths = (period.getYears() * 12) + (period.getMonths() + 1);
         return numberOfMonths < getMaxMonthsToApplyPenalty() ? numberOfMonths : getMaxMonthsToApplyPenalty();
     }
 

--- a/src/main/java/org/fenixedu/academic/domain/accounting/installments/InstallmentWithMonthlyPenalty.java
+++ b/src/main/java/org/fenixedu/academic/domain/accounting/installments/InstallmentWithMonthlyPenalty.java
@@ -92,8 +92,8 @@ public class InstallmentWithMonthlyPenalty extends InstallmentWithMonthlyPenalty
     }
 
     protected int getNumberOfMonthsToChargePenalty(DateTime when) {
-        final int numberOfMonths =
-                (new Period(getWhenStartToApplyPenalty().withDayOfMonth(1).toDateMidnight(), when.toDateMidnight()).getMonths() + 1);
+        final Period period = new Period(getWhenStartToApplyPenalty().withDayOfMonth(1).toDateMidnight(), when.toDateMidnight());
+        final int numberOfMonths = (period.getYears() * 12) + (period.getMonths() + 1);
         return numberOfMonths < getMaxMonthsToApplyPenalty() ? numberOfMonths : getMaxMonthsToApplyPenalty();
     }
 


### PR DESCRIPTION
Do not ignore years when calculating number of months for penalty.
Issue: ACDM-877

This may reopen previously closed debts! If so handle your data the way you see fit at your institution. Either you want to reopen the debt and receive the amount due or you can create excemptions in the same value as the change.