### PR TITLE
Fixed issue that blocked alumni profile completion ACDM-889 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/ui/struts/action/alumni/AlumniHomeDA.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/alumni/AlumniHomeDA.java
@@ -192,7 +192,7 @@ public class AlumniHomeDA extends FenixAction {
             if (job.getContractType() != null) {
                 numberOfHits++;
             }
-            if (job.getSalaryType() != null) {
+            if (job.getSalary() != null) {
                 numberOfHits++;
             }
             completionPercentage += (double) numberOfHits / (double) totalNumber;

--- a/src/main/webapp/alumni/index.jsp
+++ b/src/main/webapp/alumni/index.jsp
@@ -129,7 +129,7 @@ ul.material li.feedback { background: url(<%= request.getContextPath() %>/images
 		<bean:define id="educationStatus" name="educationStatus" type="java.lang.String"/>
 		<ul class="mbottom05">		
 			<li><b><bean:message key="link.professional.information" bundle="ALUMNI_RESOURCES"/>:</b> 
-				<bean:message key="message.education.sufficientData" arg0="<%= professionalStatus %>" bundle="ALUMNI_RESOURCES"/>
+				<bean:message key="message.professional.sufficientData" arg0="<%= professionalStatus %>" bundle="ALUMNI_RESOURCES"/>
 				<logic:notPresent name="dontShowJobComplete"> 
 					<html:link page="/professionalInformation.do?method=innerProfessionalInformation">
 						(<bean:message key="link.complete.data" bundle="ALUMNI_RESOURCES" />)


### PR DESCRIPTION
The completion mechanism was checking the wrong property, SalaryType,
instead of the correct one, Salary. Thus, the profile was never complete.