### PR TITLE
Handle missing ingression type on affinity cycle enrolment

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/student/Registration.java
+++ b/src/main/java/org/fenixedu/academic/domain/student/Registration.java
@@ -258,7 +258,7 @@ public class Registration extends Registration_Base {
             super.setEntryPhase(studentCandidacy.getEntryPhase());
             super.setIngressionType(studentCandidacy.getIngressionType());
 
-            if (studentCandidacy.getIngressionType().isReIngression()) {
+            if (studentCandidacy.getIngressionType() != null && studentCandidacy.getIngressionType().isReIngression()) {
                 final Degree sourceDegree = studentCandidacy.getDegreeCurricularPlan().getEquivalencePlan().getSourceDegree();
                 Registration registration = getStudent().readRegistrationByDegree(sourceDegree);
                 if (registration == null) {


### PR DESCRIPTION
  * As the generated MDCandidacy has no ingression type, the Registration
    constructor must take that into account
  * Issue: ACDM-935