### PR TITLE
Fixed filter that left out some students ACDM-943 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/reports/RaidesGraduationReportFile.java
+++ b/src/main/java/org/fenixedu/academic/domain/reports/RaidesGraduationReportFile.java
@@ -97,7 +97,8 @@ public class RaidesGraduationReportFile extends RaidesGraduationReportFile_Base 
                                     cycleType, true, registrationConclusionBean.getConclusionDate(), registrationConclusionBean
                                             .getRawGrade().getNumericValue());
                         } else if (isToAddRegistration
-                                && registration.getLastDegreeCurricularPlan().hasExecutionDegreeFor(executionYear)) {
+                                && (registration.getLastDegreeCurricularPlan().hasExecutionDegreeFor(executionYear) || registration
+                                        .hasAnyCurriculumLines(executionYear))) {
                             reportRaidesGraduate(spreadsheet, registration, getFullRegistrationPath(registration), executionYear,
                                     cycleType, false, null, registrationConclusionBean.getRawGrade().getNumericValue());
                         }


### PR DESCRIPTION
prevents students that changed to a new curricular plan from not appearing in the report