### PR TITLE
Enhance Find Person Dialog ACDM-923 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/service/services/person/PersonSearcher.java
+++ b/src/main/java/org/fenixedu/academic/service/services/person/PersonSearcher.java
@@ -81,7 +81,7 @@ public class PersonSearcher {
         } else {
             stream = Bennu.getInstance().getUserSet().stream().map(User::getProfile);
         }
-        return stream.filter(Objects::nonNull).map(UserProfile::getPerson).filter(Objects::nonNull);
+        return stream.filter(Objects::nonNull).map(UserProfile::getPerson).filter(Objects::nonNull).limit(maxHits);
     }
 
     public Stream<Person> search() {

--- a/src/main/java/org/fenixedu/academic/ui/struts/action/academicAdministration/payments/PaymentsManagementDA.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/academicAdministration/payments/PaymentsManagementDA.java
@@ -19,6 +19,7 @@
 package org.fenixedu.academic.ui.struts.action.academicAdministration.payments;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -49,7 +50,9 @@ import org.fenixedu.academic.service.services.accounting.TransferPaymentsToOther
 import org.fenixedu.academic.service.services.exceptions.FenixServiceException;
 import org.fenixedu.academic.ui.struts.action.academicAdministration.AcademicAdministrationApplication.AcademicAdminPaymentsApp;
 import org.fenixedu.academic.ui.struts.action.base.FenixDispatchAction;
+import org.fenixedu.academic.util.Bundle;
 import org.fenixedu.bennu.core.domain.User;
+import org.fenixedu.bennu.core.i18n.BundleUtil;
 import org.fenixedu.bennu.struts.annotations.Forward;
 import org.fenixedu.bennu.struts.annotations.Forwards;
 import org.fenixedu.bennu.struts.annotations.Mapping;
@@ -102,14 +105,18 @@ public class PaymentsManagementDA extends FenixDispatchAction {
                 (SimpleSearchPersonWithStudentBean) getObjectFromViewState("searchPersonBean");
         request.setAttribute("searchPersonBean", searchPersonBean);
 
-        final Collection<Person> persons = searchPersonBean.search();
+        Collection<Person> persons = searchPersonBean.search();
+        request.removeAttribute("sizeWarning");
         if (persons.size() == 1) {
             request.setAttribute("personId", persons.iterator().next().getExternalId());
 
             return showOperations(mapping, form, request, response);
 
         }
-
+        if (persons.size() > 50) {
+            persons = persons.stream().limit(50).collect(Collectors.toSet());
+            request.setAttribute("sizeWarning", BundleUtil.getString(Bundle.ACADEMIC, "warning.need.to.filter.candidates"));
+        }
         request.setAttribute("persons", persons);
         return mapping.findForward("searchPersons");
     }

--- a/src/main/resources/resources/AcademicAdminOffice_en.properties
+++ b/src/main/resources/resources/AcademicAdminOffice_en.properties
@@ -2496,6 +2496,7 @@ utilities.export.old.diplomas = Export old Diplomas
 values = values
 warning.ExtraCurricularCertificateRequest.no.enrolments.available = The student has no approved extra-curricular courses
 warning.StandaloneEnrolmentCertificateRequest.no.enrolments.available = The student has no approved standalone courses
+warning.need.to.filter.candidates = The results are truncated as too many persons were returned. Please, refine the search by adding more details.
 title.registrationDataByExecutionYear=Information by Academic Period
 label.enrolmentDate=Enrolment Date
 title.manageRegistrationDataByExecutionYear.edit=Edit Information by Academic Period

--- a/src/main/resources/resources/AcademicAdminOffice_pt.properties
+++ b/src/main/resources/resources/AcademicAdminOffice_pt.properties
@@ -2496,6 +2496,7 @@ utilities.export.old.diplomas = Exportar Diplomas antigos
 values = valores
 warning.ExtraCurricularCertificateRequest.no.enrolments.available = O aluno não tem aprovações em disciplinas extra-curriculares
 warning.StandaloneEnrolmentCertificateRequest.no.enrolments.available = O aluno não tem aprovações em disciplinas curriculares isoladas
+warning.need.to.filter.candidates = O numero de pessoas returnado foi limitado. Por favor, refine a sua procura com mais detalhes.
 title.registrationDataByExecutionYear = Informação por Período Lectivo
 label.enrolmentDate=Data de Inscrição
 title.manageRegistrationDataByExecutionYear.edit=Editar Informação por Período Lectivo

--- a/src/main/webapp/academicAdministration/payments/events/searchPersons.jsp
+++ b/src/main/webapp/academicAdministration/payments/events/searchPersons.jsp
@@ -59,6 +59,13 @@
 			
 	</logic:empty>
 	<logic:notEmpty name="persons">
+		<logic:notEmpty name="sizeWarning">
+		<p class="bg-warning">
+			<div class="alert alert-warning" role="alert">
+					<bean:write name="sizeWarning"/>
+			</div>
+		</p>
+		</logic:notEmpty>
 		<fr:view name="persons" schema="person.view-with-name-and-idDocumentType-and-documentIdNumber">
 			<fr:layout name="tabular" >
 				<fr:property name="classes" value="tstyle4"/>


### PR DESCRIPTION
This search, when made too broad, led to a clientside timeout, and to
an huge, useless, computation, on the server.

This fix introduces a limit to the number of returned results and a
warning if there are too much results, so the user can refine its search.