### PR TITLE
Allowed unlimited number of months to apply installment penalty ACDM-931 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/accounting/installments/InstallmentForFirstTimeStudents.java
+++ b/src/main/java/org/fenixedu/academic/domain/accounting/installments/InstallmentForFirstTimeStudents.java
@@ -61,14 +61,9 @@ public class InstallmentForFirstTimeStudents extends InstallmentForFirstTimeStud
 
     private void checkParameters(final Integer maxMonthsToApplyPenalty, final Integer numberOfDaysToStartApplyingPenalty) {
 
-        if (maxMonthsToApplyPenalty == null) {
+        if (maxMonthsToApplyPenalty != null && maxMonthsToApplyPenalty <= 0) {
             throw new DomainException(
-                    "error.accounting.installments.InstallmentForFirstTimeStudents.maxMonthsToApplyPenalty.cannot.be.null");
-        }
-
-        if (maxMonthsToApplyPenalty <= 0) {
-            throw new DomainException(
-                    "error.accounting.installments.InstallmentForFirstTimeStudents.maxMonthsToApplyPenalty.cannot.be.null");
+                    "error.accounting.installments.InstallmentForFirstTimeStudents.maxMonthsToApplyPenalty.must.be.greater.than.zero");
         }
 
         if (numberOfDaysToStartApplyingPenalty == null) {
@@ -107,7 +102,11 @@ public class InstallmentForFirstTimeStudents extends InstallmentForFirstTimeStud
     private int getNumberOfMonthsToChargePenalty(final Event event, final DateTime when) {
         final Period period = new Period(getWhenStartToApplyPenalty(event, when), when.toDateMidnight());
         final int numberOfMonths = (period.getYears() * 12) + (period.getMonths() + 1);
-        return numberOfMonths < getMaxMonthsToApplyPenalty() ? numberOfMonths : getMaxMonthsToApplyPenalty();
+        if (getMaxMonthsToApplyPenalty() == null) {
+            return numberOfMonths;
+        } else {
+            return numberOfMonths < getMaxMonthsToApplyPenalty() ? numberOfMonths : getMaxMonthsToApplyPenalty();
+        }
     }
 
     @Override

--- a/src/main/java/org/fenixedu/academic/domain/accounting/installments/InstallmentWithMonthlyPenalty.java
+++ b/src/main/java/org/fenixedu/academic/domain/accounting/installments/InstallmentWithMonthlyPenalty.java
@@ -63,12 +63,7 @@ public class InstallmentWithMonthlyPenalty extends InstallmentWithMonthlyPenalty
             }
         }
 
-        if (maxMonthsToApplyPenalty == null) {
-            throw new DomainException(
-                    "error.accounting.installments.InstallmentWithMonthlyPenalty.maxMonthsToApplyPenalty.cannot.be.null");
-        }
-
-        if (maxMonthsToApplyPenalty <= 0) {
+        if (maxMonthsToApplyPenalty != null && maxMonthsToApplyPenalty <= 0) {
             throw new DomainException(
                     "error.accounting.installments.InstallmentWithMonthlyPenalty.maxMonthsToApplyPenalty.must.be.greater.than.zero");
         }
@@ -94,7 +89,11 @@ public class InstallmentWithMonthlyPenalty extends InstallmentWithMonthlyPenalty
     protected int getNumberOfMonthsToChargePenalty(DateTime when) {
         final Period period = new Period(getWhenStartToApplyPenalty().withDayOfMonth(1).toDateMidnight(), when.toDateMidnight());
         final int numberOfMonths = (period.getYears() * 12) + (period.getMonths() + 1);
-        return numberOfMonths < getMaxMonthsToApplyPenalty() ? numberOfMonths : getMaxMonthsToApplyPenalty();
+        if (getMaxMonthsToApplyPenalty() == null) {
+            return numberOfMonths;
+        } else {
+            return numberOfMonths < getMaxMonthsToApplyPenalty() ? numberOfMonths : getMaxMonthsToApplyPenalty();
+        }
     }
 
     @Override

--- a/src/main/java/org/fenixedu/academic/dto/accounting/paymentPlan/InstallmentBean.java
+++ b/src/main/java/org/fenixedu/academic/dto/accounting/paymentPlan/InstallmentBean.java
@@ -167,8 +167,7 @@ public class InstallmentBean implements Serializable {
             return result;
         }
 
-        return result && this.montlyPenaltyPercentage != null && this.whenToStartApplyPenalty != null
-                && this.maxMonthsToApplyPenalty != null;
+        return result && this.montlyPenaltyPercentage != null && this.whenToStartApplyPenalty != null;
 
     }
 


### PR DESCRIPTION
When defining payment plans the maximum number of months to apply the penalty is no longer mandatory and the system now allows an unlimited number of penalty months