### PR TITLE
Add responsible to CoordinatorGroup. ACDM-1009 #resolve

### DIFF
--- a/src/main/dml/fenixedu-academic.dml
+++ b/src/main/dml/fenixedu-academic.dml
@@ -4580,6 +4580,7 @@ class accessControl.PersistentTeacherGroup extends .org.fenixedu.bennu.core.doma
 class accessControl.PersistentScientificCommissionGroup extends .org.fenixedu.bennu.core.domain.groups.PersistentGroup;
 
 class accessControl.PersistentCoordinatorGroup extends accessControl.FenixPredicateGroup {
+    Boolean responsible;
 }
 
 class accessControl.PersistentAcademicOperationGroup extends accessControl.FenixPredicateGroup {

--- a/src/main/java/org/fenixedu/academic/domain/accessControl/PersistentCoordinatorGroup.java
+++ b/src/main/java/org/fenixedu/academic/domain/accessControl/PersistentCoordinatorGroup.java
@@ -27,9 +27,15 @@ import org.fenixedu.academic.domain.degree.DegreeType;
 import org.fenixedu.bennu.core.groups.Group;
 
 public class PersistentCoordinatorGroup extends PersistentCoordinatorGroup_Base {
+
     protected PersistentCoordinatorGroup(DegreeType degreeType, Degree degree) {
+        this(degreeType, degree, null);
+    }
+
+    protected PersistentCoordinatorGroup(DegreeType degreeType, Degree degree, Boolean responsible) {
         super();
         setDegreeType(degreeType);
+        setResponsible(responsible);
         setDegree(degree);
         if (degree != null) {
             setRootForFenixPredicate(null);
@@ -38,7 +44,7 @@ public class PersistentCoordinatorGroup extends PersistentCoordinatorGroup_Base 
 
     @Override
     public Group toGroup() {
-        return CoordinatorGroup.get(getDegreeType(), getDegree());
+        return CoordinatorGroup.get(getDegreeType(), getDegree(), getResponsible());
     }
 
     @Override
@@ -48,18 +54,23 @@ public class PersistentCoordinatorGroup extends PersistentCoordinatorGroup_Base 
     }
 
     public static PersistentCoordinatorGroup getInstance() {
-        return getInstance(null, null);
+        return getInstance(null, null, null);
     }
 
     public static PersistentCoordinatorGroup getInstance(DegreeType degreeType, Degree degree) {
-        return singleton(() -> select(degreeType, degree), () -> new PersistentCoordinatorGroup(degreeType, degree));
+        return getInstance(degreeType, degree, null);
     }
 
-    private static Optional<PersistentCoordinatorGroup> select(final DegreeType degreeType, final Degree degree) {
+    public static PersistentCoordinatorGroup getInstance(DegreeType degreeType, Degree degree, Boolean responsible) {
+        return singleton(() -> select(degreeType, degree, responsible),
+                () -> new PersistentCoordinatorGroup(degreeType, degree, responsible));
+    }
+
+    private static Optional<PersistentCoordinatorGroup> select(final DegreeType degreeType, final Degree degree,
+            Boolean responsible) {
         Stream<PersistentCoordinatorGroup> stream =
                 degree != null ? degree.getCoordinatorGroupSet().stream() : filter(PersistentCoordinatorGroup.class);
-        return stream.filter(
-                group -> Objects.equals(group.getDegreeType(), degreeType) && Objects.equals(group.getDegree(), degree))
-                .findAny();
+        return stream.filter(group -> Objects.equals(group.getDegreeType(), degreeType)
+                && Objects.equals(group.getDegree(), degree) && Objects.equals(group.getResponsible(), responsible)).findAny();
     }
 }


### PR DESCRIPTION
Add responsible groupArgument to CoordinatorGroup.
From now on it is possible to create a CoordinatorGroup with
responsible. Null is a possible value meaning responsible and
non-responsible coordinators, keeping the original semantics.

Issue: ACDM-1009