### PR TITLE
Manage accounts interface problems ACDM-642 #resolve

### DIFF
--- a/src/main/webapp/accounts/createPerson.jsp
+++ b/src/main/webapp/accounts/createPerson.jsp
@@ -23,6 +23,7 @@
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
 <%@ taglib uri="http://struts.apache.org/tags-logic" prefix="logic"%>
 <%@ taglib uri="http://fenix-ashes.ist.utl.pt/fenix-renderers" prefix="fr" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 
 <h2><bean:message key="create.person.title" bundle="MANAGER_RESOURCES"/></h2>
 
@@ -54,24 +55,31 @@
 		<html:submit onclick="this.form.method.value='showExistentPersonsWithSameMandatoryDetails';"><bean:message key="label.search" bundle="MANAGER_RESOURCES" /></html:submit>
 
 		<logic:notEmpty name="resultPersons">
-			<fr:view name="resultPersons">
-				<fr:schema type="org.fenixedu.academic.domain.Person" bundle="MANAGER_RESOURCES">
-					<fr:slot name="username" layout="link" key="label.name">
-						<fr:property name="linkFormat"
-							value="/accounts/manageAccounts.do?method=viewPerson&amp;personId=\${externalId}" />
-						<fr:property name="useParent" value="true" />
-						<fr:property name="format" value="\${profile.fullName} (\${username})" />
-					</fr:slot>
-					<fr:slot name="documentIdNumber" layout="format">
-						<fr:property name="format" value="\${documentIdNumber} (\${idDocumentType.localizedName})" />
-						<fr:property name="useParent" value="true" />
-					</fr:slot>
-					<fr:slot name="profile.email" key="label.email" />
-					<fr:slot name="dateOfBirth" />
-					<fr:slot name="nationality.localizedName.content" key="label.nationality" />
-				</fr:schema>
-				<fr:layout name="tabular" />
-			</fr:view>
+			<c:set var="req" value="${pageContext.request}" />
+			<table class="table">
+				<thead>
+					<tr>
+						<th><label><bean:message bundle="MANAGER_RESOURCES" key="label.name"/></label></th>
+						<th><label><bean:message bundle="MANAGER_RESOURCES" key="label.documentIdNumber"/></label></th>
+						<th><label><bean:message bundle="MANAGER_RESOURCES" key="label.email"/></label></th>
+						<th><label><bean:message bundle="MANAGER_RESOURCES" key="label.dateOfBirth"/></label></th>
+						<th><label><bean:message bundle="MANAGER_RESOURCES" key="label.nationality"/></label></th>
+					</tr>
+				</thead>
+				<tbody>
+					<logic:iterate name="resultPersons" id="resultPerson">
+						<tr>
+							<td><a href="${fr:checksumLink(req, '/accounts/manageAccounts.do?method=viewPerson&amp;personId='.concat(resultPerson.externalId))}"><bean:write name="resultPerson" property="profile.fullName"/>(<bean:write name="resultPerson" property="username"/>)</a></td>
+							<td><bean:write name="resultPerson" property="documentIdNumber"/> (<bean:write name="resultPerson" property="idDocumentType.localizedName"/>)</td>
+							<td><bean:write name="resultPerson" property="profile.email"/></td>
+							<td><bean:write name="resultPerson" property="dateOfBirth" format="dd/MM/yyyy"/></td>
+							<logic:present name="resultPerson" property="nationality">
+								<td><bean:write name="resultPerson" property="nationality.localizedName"/></td>
+							</logic:present>
+						</tr>
+					</logic:iterate>
+				</tbody>
+			</table>
 		</logic:notEmpty>
 		<logic:present name="resultPersons">
 			<html:submit onclick="this.form.method.value='prepareCreatePersonFillInformation';"><bean:message key="link.create.person.because.does.not.exist" bundle="MANAGER_RESOURCES" /></html:submit>


### PR DESCRIPTION
ACDM-642 was being caused by a null nationality, when trying to get `nationality.localizedName.content`. In order to fix this, the results table had to be re-written without renderers.