### PR TITLE
Teachers wrongly warned about missing grades submission ACDM-1060 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/dto/degreeAdministrativeOffice/gradeSubmission/GradesToSubmitExecutionCourseSendMailBean.java
+++ b/src/main/java/org/fenixedu/academic/dto/degreeAdministrativeOffice/gradeSubmission/GradesToSubmitExecutionCourseSendMailBean.java
@@ -82,7 +82,8 @@ public class GradesToSubmitExecutionCourseSendMailBean implements Serializable {
         int count = 0;
 
         for (final CurricularCourse curricularCourse : executionCourse.getAssociatedCurricularCoursesSet()) {
-            if (degreeCurricularPlan != null && degreeCurricularPlan.equals(curricularCourse.getDegreeCurricularPlan())) {
+            if (degreeCurricularPlan == null || (degreeCurricularPlan != null
+                    && degreeCurricularPlan.equals(curricularCourse.getDegreeCurricularPlan()))) {
                 count += getNumberOfStudentsWithoutGrade(curricularCourse);
             }
         }


### PR DESCRIPTION
When no curricular plan was specified, the number of students without grade would not be counted, which was causing it to show up as 0.