### PR TITLE
Correct RaidesSpecializationReportFile's Degree Type treatment ACDM-1088 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/reports/RaidesSpecializationReportFile.java
+++ b/src/main/java/org/fenixedu/academic/domain/reports/RaidesSpecializationReportFile.java
@@ -30,6 +30,8 @@ import org.fenixedu.academic.domain.degreeStructure.CycleType;
 import org.fenixedu.academic.domain.student.Registration;
 import org.fenixedu.academic.domain.studentCurriculum.CycleCurriculumGroup;
 import org.fenixedu.academic.dto.student.RegistrationConclusionBean;
+import org.fenixedu.academic.util.Bundle;
+import org.fenixedu.bennu.core.i18n.BundleUtil;
 import org.fenixedu.commons.spreadsheet.Spreadsheet;
 import org.fenixedu.commons.spreadsheet.Spreadsheet.Row;
 import org.joda.time.YearMonthDay;
@@ -55,8 +57,11 @@ public class RaidesSpecializationReportFile extends RaidesSpecializationReportFi
     }
 
     @Override
-    public DegreeType getDegreeType() {
-        return DegreeType.matching(DegreeType::isSpecializationDegree).get();
+    public void setDegreeType(DegreeType type) {
+        if(!type.isSpecializationDegree()) {
+            throw new IllegalArgumentException(BundleUtil.getString(Bundle.GEP,"error.reports.raides.specialization.degree.type"));
+        }
+        super.setDegreeType(type);
     }
 
     @Override

--- a/src/main/resources/resources/GEPResources_en.properties
+++ b/src/main/resources/resources/GEPResources_en.properties
@@ -15,6 +15,7 @@ error.ects.invalidLine.nonMatchingCourse = A entidade com o código {0} não corre
 error.ects.invalidTable = Tabela de comparabilidade num formato errado: {0}
 error.ects.table.unableToReadTablesFile = Erro na importação do ficheiro, contacte o suporte.
 error.ects.unable.to.convert.grade = Não foi possível converter a nota para a escala ECTS por falta de tabelas de conversão, contacte o suporte.
+error.reports.raides.specialization.degree.type = Supplied Raides Specialization Report's Degree Type is not a Specialization
 label.acred.categoryResponsibleTeacher = Category:
 label.acred.course = Discipline:
 label.acred.courseInfo = DISCIPLINE FORM

--- a/src/main/resources/resources/GEPResources_pt.properties
+++ b/src/main/resources/resources/GEPResources_pt.properties
@@ -15,6 +15,7 @@ error.ects.invalidLine.nonMatchingCourse = A entidade com o código {0} não corre
 error.ects.invalidTable = Tabela de comparabilidade num formato errado: {0}
 error.ects.table.unableToReadTablesFile = Erro na importação do ficheiro, contacte o suporte.
 error.ects.unable.to.convert.grade = Não foi possível converter a nota para a escala ECTS por falta de tabelas de conversão, contacte o suporte.
+error.reports.raides.specialization.degree.type = Tipo de Curso indicado para a Listagem de RAIDES Especialização não é uma Especialização
 label.acred.categoryResponsibleTeacher = Categoria:
 label.acred.course = Disciplina:
 label.acred.courseInfo = FICHA DISCIPLINA


### PR DESCRIPTION
Delete RaidesSpecializationReportFile degree type getter in favor of the base getter
Override degree type setter to throw IllegalArgumentException if given a non specialization degree type