### PR TITLE
StudentListByDegreeDA: unable to search by StudentStatute. ACDM-948 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/ui/renderers/providers/StudentStatuteTypeProvider.java
+++ b/src/main/java/org/fenixedu/academic/ui/renderers/providers/StudentStatuteTypeProvider.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.fenixedu.academic.domain.student.StatuteType;
 
+@Deprecated
 public class StudentStatuteTypeProvider extends AbstractDomainObjectProvider {
 
     @Override

--- a/src/main/java/org/fenixedu/academic/ui/renderers/providers/choiceType/replacement/multiple/StudentStatuteTypeProvider.java
+++ b/src/main/java/org/fenixedu/academic/ui/renderers/providers/choiceType/replacement/multiple/StudentStatuteTypeProvider.java
@@ -21,12 +21,21 @@ package org.fenixedu.academic.ui.renderers.providers.choiceType.replacement.mult
 import java.util.stream.Collectors;
 
 import org.fenixedu.academic.domain.student.StatuteType;
-import org.fenixedu.academic.ui.renderers.providers.AbstractDomainObjectProvider;
 
-public class StudentStatuteTypeProvider extends AbstractDomainObjectProvider {
+import pt.ist.fenixWebFramework.rendererExtensions.converters.DomainObjectKeyArrayConverter;
+import pt.ist.fenixWebFramework.renderers.DataProvider;
+import pt.ist.fenixWebFramework.renderers.components.converters.Converter;
+
+public class StudentStatuteTypeProvider implements DataProvider {
 
     @Override
     public Object provide(Object source, Object currentValue) {
         return StatuteType.readAll().collect(Collectors.toList());
     }
+    
+    @Override
+    public Converter getConverter() {
+        return new DomainObjectKeyArrayConverter();
+    }
+    
 }

--- a/src/main/java/org/fenixedu/academic/ui/renderers/providers/choiceType/replacement/single/StudentStatuteTypeProvider.java
+++ b/src/main/java/org/fenixedu/academic/ui/renderers/providers/choiceType/replacement/single/StudentStatuteTypeProvider.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.fenixedu.academic.domain.student.StatuteType;
 import org.fenixedu.academic.ui.renderers.providers.AbstractDomainObjectProvider;
 
+@Deprecated
 public class StudentStatuteTypeProvider extends AbstractDomainObjectProvider {
 
     @Override


### PR DESCRIPTION
Following exception occurs when any student statute is chosen:

java.lang.ClassCastException: [Ljava.lang.String; cannot be cast to java.lang.String
	at pt.ist.fenixWebFramework.rendererExtensions.converters.DomainObjectKeyConverter.convert(DomainObjectKeyConverter.java:34)

Issue: ACDM-948