### PR TITLE
Add missing string resources for MoveCandidacy ACDM-1082 #resolve

### DIFF
--- a/src/main/resources/resources/CaseHandlingResources_en.properties
+++ b/src/main/resources/resources/CaseHandlingResources_en.properties
@@ -169,6 +169,7 @@ org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualC
 org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualCandidacyProcess$RejectCandidacy = Excluir Candidato
 org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualCandidacyProcess$RevertApplicationToStandBy = Reverter para pendente
 org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualCandidacyProcess$SetNotAcceptedState = Modificar o estado do processo em 'Não Colocado'
+org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualCandidacyProcess$MoveCandidacy = Mover candidatura
 org.fenixedu.academic.domain.candidacyProcess.standalone.StandaloneCandidacyProcess$CreateCandidacyPeriod = Criar processo candidatura
 org.fenixedu.academic.domain.candidacyProcess.standalone.StandaloneCandidacyProcess$CreateRegistrations = Criar matrículas
 org.fenixedu.academic.domain.candidacyProcess.standalone.StandaloneCandidacyProcess$EditCandidacyPeriod = Editar períodos de candidatura

--- a/src/main/resources/resources/CaseHandlingResources_pt.properties
+++ b/src/main/resources/resources/CaseHandlingResources_pt.properties
@@ -169,6 +169,7 @@ org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualC
 org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualCandidacyProcess$RejectCandidacy = Excluir Candidato
 org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualCandidacyProcess$RevertApplicationToStandBy = Reverter para pendente
 org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualCandidacyProcess$SetNotAcceptedState = Modificar o estado do processo em 'Não Colocado'
+org.fenixedu.academic.domain.candidacyProcess.secondCycle.SecondCycleIndividualCandidacyProcess$MoveCandidacy = Mover candidatura
 org.fenixedu.academic.domain.candidacyProcess.standalone.StandaloneCandidacyProcess$CreateCandidacyPeriod = Criar processo candidatura
 org.fenixedu.academic.domain.candidacyProcess.standalone.StandaloneCandidacyProcess$CreateRegistrations = Criar matrículas
 org.fenixedu.academic.domain.candidacyProcess.standalone.StandaloneCandidacyProcess$EditCandidacyPeriod = Editar períodos de candidatura


### PR DESCRIPTION
Notice that the destination page's title refers to the Candidate instead of the Candidacy (which is inconsistent).
Also, there's a bunch (or most) of English resources for this page that are a copy of the Portuguese version. I added these new strings in Portuguese as well to ensure consistency.