### PR TITLE
Fix NPE on verifying approval of AlumniIdentityCheckRequest ACDM-1209 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/Alumni.java
+++ b/src/main/java/org/fenixedu/academic/domain/Alumni.java
@@ -484,7 +484,7 @@ public class Alumni extends Alumni_Base {
                 if (!hasPasswordRequest) {
                     hasPasswordRequest = true;
                 }
-                if (request.getApproved()) {
+                if (request.isApproved()) {
                     hasPasswordRequestAccepted = true;
                     break;
                 }

--- a/src/main/java/org/fenixedu/academic/domain/AlumniIdentityCheckRequest.java
+++ b/src/main/java/org/fenixedu/academic/domain/AlumniIdentityCheckRequest.java
@@ -130,6 +130,14 @@ public class AlumniIdentityCheckRequest extends AlumniIdentityCheckRequest_Base 
                 && (!StringUtils.isEmpty(person.getNameOfMother()) && person.getNameOfMother().equals(getNameOfMother()));
     }
 
+    public boolean isApproved() {
+        return Boolean.TRUE.equals(getApproved());
+    }
+
+    public boolean isPending() {
+        return getApproved() == null;
+    }
+
     public void validate(Boolean approval) {
         setApproved(approval);
         setDecisionDateTime(new DateTime());


### PR DESCRIPTION
Approval field of AlumniIdentityCheckRequest is a Boolean (not the primitive type boolean) and it is not initialized during the creation of the object so it can be null when a request is pending.