### PR TITLE
Add quotes to response header in export to excel ACDM-1365 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/ui/struts/action/administrativeOffice/lists/StudentListByDegreeDA.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/administrativeOffice/lists/StudentListByDegreeDA.java
@@ -276,7 +276,7 @@ public class StudentListByDegreeDA extends FenixDispatchAction {
             filename += "_" + executionYear.getYear();
 
             response.setContentType("application/vnd.ms-excel");
-            response.setHeader("Content-disposition", "attachment; filename=" + filename + ".xls");
+            response.setHeader("Content-disposition", "attachment; filename=\"" + filename + ".xls\"");
             ServletOutputStream writer = response.getOutputStream();
 
             final String param = request.getParameter("extendedInfo");

--- a/src/main/java/org/fenixedu/academic/ui/struts/action/administrativeOffice/lists/StudentsListByCurricularCourseDA.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/administrativeOffice/lists/StudentsListByCurricularCourseDA.java
@@ -192,7 +192,7 @@ public class StudentsListByCurricularCourseDA extends FenixDispatchAction {
                             + curricularCourse.getDegreeCurricularPlan().getName() + ")_" + executionYear.getYear();
 
             response.setContentType("application/vnd.ms-excel");
-            response.setHeader("Content-disposition", "attachment; filename=" + filename.replace(" ", "_") + ".xls");
+            response.setHeader("Content-disposition", "attachment; filename=\"" + filename.replace(" ", "_") + ".xls\"");
             ServletOutputStream writer = response.getOutputStream();
 
             exportToXls(searchStudentByCriteria(executionYear, curricularCourse, semester), writer, executionYear,


### PR DESCRIPTION
This filename is used to create the response header as such it is now in double quotes as commas can generate issues.

Fixed the issue with listings by curricular course as well.