### PR TITLE
Shift reservation now attends to all registrations ACDM-1359 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/student/Registration.java
+++ b/src/main/java/org/fenixedu/academic/domain/student/Registration.java
@@ -1441,8 +1441,9 @@ public class Registration extends Registration_Base {
     }
 
     final public Set<SchoolClass> getSchoolClassesToEnrolBy(final ExecutionCourse executionCourse) {
-        Set<SchoolClass> schoolClasses =
-                executionCourse.getSchoolClassesBy(getActiveStudentCurricularPlan().getDegreeCurricularPlan());
+        StudentCurricularPlan scp = getActiveStudentCurricularPlan();
+        Set<SchoolClass> schoolClasses = scp != null ? executionCourse
+                .getSchoolClassesBy(scp.getDegreeCurricularPlan()) : new HashSet<SchoolClass>();
         return schoolClasses.isEmpty() ? executionCourse.getSchoolClasses() : schoolClasses;
     }
 

--- a/src/main/java/org/fenixedu/academic/ui/struts/action/student/enrollment/ShiftStudentEnrollmentManagerLookupDispatchAction.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/student/enrollment/ShiftStudentEnrollmentManagerLookupDispatchAction.java
@@ -21,6 +21,7 @@ package org.fenixedu.academic.ui.struts.action.student.enrollment;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -84,7 +85,7 @@ public class ShiftStudentEnrollmentManagerLookupDispatchAction extends FenixDisp
 
     private Registration getAndSetRegistration(final HttpServletRequest request) {
         final Registration registration = FenixFramework.getDomainObject(request.getParameter("registrationOID"));
-        if (!getUserView(request).getPerson().getStudent().getRegistrationsToEnrolInShiftByStudent().contains(registration)) {
+        if (!getUserView(request).getPerson().getStudent().getRegistrationStream().anyMatch(r -> r.equals(registration))) {
             return null;
         }
 
@@ -102,6 +103,11 @@ public class ShiftStudentEnrollmentManagerLookupDispatchAction extends FenixDisp
         if (registration == null) {
             addActionMessage(request, "errors.impossible.operation");
             return mapping.getInputForward();
+        }
+
+        if (registration.getActiveStudentCurricularPlan() == null) {
+            addActionMessage(request, "errors.student.registration.noActiveCurricularPlan");
+            return mapping.findForward("prepareShiftEnrollment");
         }
 
         checkParameter(request);
@@ -195,7 +201,11 @@ public class ShiftStudentEnrollmentManagerLookupDispatchAction extends FenixDisp
         request.setAttribute("infoClasslessons", infoClasslessons);
         request.setAttribute("infoClasslessonsEndTime", Integer.valueOf(getEndTime(infoClasslessons)));
 
-        final List<InfoShowOccupation> infoLessons = ReadStudentTimeTable.run(registration, executionSemester);
+        final List<InfoShowOccupation> infoLessons = new ArrayList<InfoShowOccupation>();
+
+        for (Registration reg : registration.getStudent().getRegistrationStream().collect(Collectors.toList())) {
+            infoLessons.addAll(ReadStudentTimeTable.run(reg, executionSemester));
+        }
         request.setAttribute("person", registration.getPerson());
         request.setAttribute("infoLessons", infoLessons);
         request.setAttribute("infoLessonsEndTime", Integer.valueOf(getEndTime(infoLessons)));

--- a/src/main/resources/resources/StudentResources_en.properties
+++ b/src/main/resources/resources/StudentResources_en.properties
@@ -186,6 +186,7 @@ errors.required = You should specify: {0}
 errors.student.already.enroled = You cannot remove courses in which you are enrolled at the academic office.
 errors.student.already.enroled.in.group = You cannot remove the course in which you are enrolled in working groups.
 errors.student.already.enroled.in.shift = You cannot remove courses for which you are enrolled in shifts.
+errors.student.registration.noActiveCurricularPlan = It's not possible to subscribe to this course in this enrollment.
 errors.suffix = </span></li>
 errors.unEnrollStudentGroupShift.notEnroled = You cannot dissociate the shift, because you are not enrolled in the group.
 errors.unEnrollStudentGroupShift.shiftFull = You cannot dissociate the shift of your group, because the no-shift group is full.

--- a/src/main/resources/resources/StudentResources_pt.properties
+++ b/src/main/resources/resources/StudentResources_pt.properties
@@ -186,6 +186,7 @@ errors.required = Deverá definir: {0}
 errors.student.already.enroled = Não pode remover disciplinas em que se encontra inscrito na secretaria.
 errors.student.already.enroled.in.group = Não pode remover a disciplina em que se encontra inscrito em grupos de trabalho.
 errors.student.already.enroled.in.shift = Não pode remover disciplina em que se encontra inscrito em turnos.
+errors.student.registration.noActiveCurricularPlan = Não é possível inscrever-se nesta disciplina com esta matrícula.
 errors.suffix = </span></li>
 errors.unEnrollStudentGroupShift.notEnroled = Não pode dissociar o turno, pois não está inscrito no grupo.
 errors.unEnrollStudentGroupShift.shiftFull = Não pode dissociar o turno do seu grupo, pois o agrupamento do tipo sem turno está cheio.


### PR DESCRIPTION
- Before shift reservations students have to choose which reservation they want.
- In extra-curricular page it is not possible to add a course if the chosen registration is not active.
- In shift reservations students can see the schedule for all registrations combined but if they want to reserve shifts they need to select the registration that contains it.