### PR TITLE
Name shown as json object in view mobility agreements functionality ACDM-1292 #resolve

### DIFF
--- a/src/main/webapp/candidacy/erasmus/viewErasmusVacancies.jsp
+++ b/src/main/webapp/candidacy/erasmus/viewErasmusVacancies.jsp
@@ -53,7 +53,7 @@
 			<fr:slot name="mobilityProgram" layout="menu-select-postback">
 				<fr:property name="destination" value="postback" />
 				<fr:property name="providerClass" value="org.fenixedu.academic.ui.struts.action.candidacy.erasmus.MobilityProgramAllProvider" />
-				<fr:property name="format" value="${name}" />
+				<fr:property name="format" value="${name.content}" />
 				<fr:property name="sortBy" value="name"/>
 			</fr:slot>
 			


### PR DESCRIPTION
- Missing .content in viewErasmusVacancies.jsp to show program's name properly.

