### PR TITLE
Manage Associated Objects - Create Scientific Area throws NPE ACDM-1276 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/ui/struts/action/manager/ManageAssociatedObjects.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/manager/ManageAssociatedObjects.java
@@ -40,6 +40,7 @@ import org.fenixedu.academic.domain.administrativeOffice.AdministrativeOffice;
 import org.fenixedu.academic.domain.administrativeOffice.AdministrativeOfficeType;
 import org.fenixedu.academic.domain.degree.DegreeType;
 import org.fenixedu.academic.domain.degreeStructure.CycleType;
+import org.fenixedu.academic.domain.exceptions.DomainException;
 import org.fenixedu.academic.domain.organizationalStructure.AccountabilityType;
 import org.fenixedu.academic.domain.organizationalStructure.AccountabilityTypeEnum;
 import org.fenixedu.academic.domain.organizationalStructure.AggregateUnit;
@@ -69,7 +70,7 @@ import pt.ist.fenixframework.FenixFramework;
 @StrutsFunctionality(app = ManagerSystemManagementApp.class, path = "manage-associated-objects",
         titleKey = "title.manage.associated.objects")
 @Mapping(path = "/manageAssociatedObjects", module = "manager")
-@Forwards({ @Forward(name = "show", path = "/manager/listAssociatedObjects.jsp"),
+@Forwards({ 
         @Forward(name = "list", path = "/manager/listAssociatedObjects.jsp"),
         @Forward(name = "createDepartment", path = "/manager/createDepartment.jsp"),
         @Forward(name = "createEmptyDegree", path = "/manager/createEmptyDegree.jsp"),
@@ -78,7 +79,8 @@ import pt.ist.fenixframework.FenixFramework;
         @Forward(name = "createCompetenceCourseGroup", path = "/manager/createCompetenceCourseGroup.jsp"),
         @Forward(name = "associatePersonUnit", path = "/manager/associatePersonUnit.jsp"),
         @Forward(name = "createAcademicOffice", path = "/manager/createAcademicOffice.jsp"),
-        @Forward(name = "createDegreeType", path = "/manager/createDegreeType.jsp") })
+        @Forward(name = "createDegreeType", path = "/manager/createDegreeType.jsp") 
+})
 public class ManageAssociatedObjects extends FenixDispatchAction {
     public static class AssociatedObjectsBean implements Serializable {
         private boolean active;
@@ -570,7 +572,14 @@ public class ManageAssociatedObjects extends FenixDispatchAction {
             HttpServletResponse response) throws Exception {
         AssociatedObjectsBean bean = getRenderedObject("admOffice");
 
-        createScientificArea(bean);
+        try {
+            createScientificArea(bean);
+        } catch (final DomainException e) {
+            addActionMessage(request, e.getMessage(), e.getArgs());
+            request.setAttribute("bean", bean);
+
+            return mapping.findForward("createScientificArea");
+        }
 
         return list(mapping, form, request, response);
     }

--- a/src/main/resources/resources/ManagerResources_en.properties
+++ b/src/main/resources/resources/ManagerResources_en.properties
@@ -133,6 +133,7 @@ error.ExecutionPeriod.intersection.dates = Dates intersect with another executio
 error.ExecutionPeriod.invalid.dates = Invalid dates
 error.ExecutionYear.exceeded.number.of.executionPeriods = Number of Periods Running for the year exceeded Execution [{0}]
 error.NotAuthorized = Operation Not Permitted
+error.Party.empty.partyName = Name required.
 error.PaymentCodeMapping.find.existing.code = There is already a mapping between and {0} {1}
 error.ROLE_TYPE_ALIAS.already.exists = Already have alias based on that role.
 error.RootEntry.invalid.templateEntry = Calendar redefining invalid (note: if the calendar entries already has redefined virtual or reset the original schedule can not be changed)

--- a/src/main/resources/resources/ManagerResources_pt.properties
+++ b/src/main/resources/resources/ManagerResources_pt.properties
@@ -133,6 +133,7 @@ error.ExecutionPeriod.intersection.dates = As datas intersectam outro período de
 error.ExecutionPeriod.invalid.dates = As datas são inválidas
 error.ExecutionYear.exceeded.number.of.executionPeriods = Número de Períodos em Execução excedido para o ano de Execução [{0}]
 error.NotAuthorized = Operação Não Autorizada
+error.Party.empty.partyName = Nome obrigatório.
 error.PaymentCodeMapping.find.existing.code = Já existe um mapeamento entre {0} e {1}
 error.ROLE_TYPE_ALIAS.already.exists = Já possui alias baseado nesse role.
 error.RootEntry.invalid.templateEntry = Calendário a redefinir inválido (nota: se o calendário já possui entradas redefinidas, virtuais ou originais o calendário a redefinir não pode ser alterado)

--- a/src/main/webapp/manager/createScientificArea.jsp
+++ b/src/main/webapp/manager/createScientificArea.jsp
@@ -30,6 +30,17 @@
 <html:xhtml/>
 
 <h2>Create Scientific Area</h2>
+
+<logic:messagesPresent message="true">
+    <p>
+        <span class="error0"><!-- Error messages go here -->
+            <html:messages id="message" message="true" bundle="MANAGER_RESOURCES">
+                <bean:write name="message"/>
+            </html:messages>
+        </span>
+    <p>
+</logic:messagesPresent>
+
 <fr:edit id="admOffice" name="bean" action="/manageAssociatedObjects.do?method=createScientificArea">
     <fr:schema bundle="MANAGER_RESOURCES"
                type="org.fenixedu.academic.ui.struts.action.manager.ManageAssociatedObjects$AssociatedObjectsBean">
@@ -40,7 +51,7 @@
         <fr:slot name="code" key="label.manager.code">
         </fr:slot>
 
-        <fr:slot name="department" layout="menu-select" key="label.username">
+        <fr:slot name="department" layout="menu-select" key="label.username" required="true">
             <fr:property name="from" value="departments"/>
             <fr:property name="format" value="${realName}"/>
         </fr:slot>
@@ -49,5 +60,6 @@
         <fr:property name="classes"
                      value="tstyle5 thleft thlight thmiddle mto p05"/>
         <fr:property name="columnClasses" value=",,tdclear tderror1"/>
+        <fr:destination name="cancel" path="/manageAssociatedObjects.do?method=list"/>
     </fr:layout>
 </fr:edit>


### PR DESCRIPTION
**Action**: press either "submit" or "cancel" buttons with empty fields

**"Cancel" Case**
- Cancel button action was not defined so it defaulted to "submit" behavior.
  - Fixed by using fr:destination tag to define cancel action.

**"Submit" Case**
- createScientificArea method tried to get a DepartmentUnit from a null (empty field) when calling bean.getDepartment().getDepartmentUnit().
  - Fixed by making the department mandatory
- Also, with only empty name field a DomainException was thrown and not handled.
  - Fixed with try/catch to handle domain exception and added error message.

**Extra Refactoring**
- Removed forward mapping "show" since it had no references in the code
