### PR TITLE
Improve multiple payments interface logic ACDM-1493

### DIFF
--- a/src/main/java/org/fenixedu/academic/domain/accounting/calculator/Debt.java
+++ b/src/main/java/org/fenixedu/academic/domain/accounting/calculator/Debt.java
@@ -70,6 +70,10 @@ public class Debt extends DebtEntry {
         return getOpenAmount().add(getOpenInterestAmount()).add(getOpenFineAmount());
     }
 
+    public BigDecimal getTotalOpenPenaltyAmount() {
+        return getOpenInterestAmount().add(getOpenFineAmount());
+    }
+
     public boolean isOpenFine() {
         return fines.stream().anyMatch(Fine::isOpen);
     }

--- a/src/main/java/org/fenixedu/academic/domain/accounting/events/gratuity/GratuityEvent.java
+++ b/src/main/java/org/fenixedu/academic/domain/accounting/events/gratuity/GratuityEvent.java
@@ -97,25 +97,17 @@ public abstract class GratuityEvent extends GratuityEvent_Base {
 
     @Override
     public LabelFormatter getDescriptionForEntryType(EntryType entryType) {
-        final LabelFormatter labelFormatter = new LabelFormatter();
-        labelFormatter.appendLabel(entryType.name(), Bundle.ENUMERATION).appendLabel(" (")
-                .appendLabel(getDegree().getDegreeType().getName().getContent()).appendLabel(" - ")
-                .appendLabel(getDegree().getNameFor(getExecutionYear()).getContent()).appendLabel(" - ")
+        return new LabelFormatter()
+                .appendLabel(entryType.name(), Bundle.ENUMERATION).appendLabel(" (")
+                .appendLabel(getDegree().getSigla()).appendLabel(" - ")
                 .appendLabel(getExecutionYear().getYear()).appendLabel(")");
-
-        return labelFormatter;
     }
 
     @Override
     public LabelFormatter getDescription() {
-        final LabelFormatter labelFormatter = super.getDescription();
-
-        labelFormatter.appendLabel(" ");
-//        labelFormatter.appendLabel(getDegree().getDegreeType().getName().getContent()).appendLabel(" - ");
-//        labelFormatter.appendLabel(getDegree().getNameFor(getExecutionYear()).getContent()).appendLabel(" - ");
-        labelFormatter.appendLabel(getDegree().getSigla()).appendLabel(" - ");
-        labelFormatter.appendLabel(getExecutionYear().getYear());
-        return labelFormatter;
+        return super.getDescription().appendLabel(" ")
+                .appendLabel(getDegree().getSigla()).appendLabel(" - ")
+                .appendLabel(getExecutionYear().getYear());
     }
 
     @Override

--- a/src/main/java/org/fenixedu/academic/dto/accounting/PaymentsManagementDTO.java
+++ b/src/main/java/org/fenixedu/academic/dto/accounting/PaymentsManagementDTO.java
@@ -116,4 +116,5 @@ public class PaymentsManagementDTO implements Serializable {
     public void setPaymentReference(String paymentReference) {
         this.paymentReference = paymentReference;
     }
+
 }

--- a/src/main/java/org/fenixedu/academic/ui/spring/controller/AccountingController.java
+++ b/src/main/java/org/fenixedu/academic/ui/spring/controller/AccountingController.java
@@ -23,6 +23,7 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.springframework.context.MessageSource;
 import org.springframework.ui.Model;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -100,7 +101,7 @@ public abstract class AccountingController {
     }
 
     @RequestMapping("{event}/debt/{debtDueDate}/details")
-    public String debtDetails(@PathVariable Event event, @PathVariable LocalDate debtDueDate, Model model, User loggedUser) {
+    public String debtDetails(@PathVariable Event event, @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate debtDueDate, Model model, User loggedUser) {
         accessControlService.checkEventOwnerOrPaymentManager(event, loggedUser);
 
         final DebtInterestCalculator debtInterestCalculator = event.getDebtInterestCalculator(new DateTime());

--- a/src/main/webapp/WEB-INF/fenixedu-academic/accounting/event-debt-details.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/accounting/event-debt-details.jsp
@@ -27,14 +27,14 @@
 
 <link rel="stylesheet" type="text/css" media="screen" href="<%= request.getContextPath() %>/CSS/accounting.css"/>
 
-<spring:url var="payUrl" value="{event}/pay">
+<spring:url var="payUrl" value="../../../{event}/pay">
     <spring:param name="event" value="${eventId}"/>
 </spring:url>
 <spring:url var="backUrl" value="../../../{event}/details">
     <spring:param name="event" value="${eventId}"/>
 </spring:url>
 
-<c:set var="totalAmount" value="#{debt.openAmount + debt.openInterestAmount}"/>
+<c:set var="totalAmount" value="#{debt.totalOpenAmount}"/>
 
 <div class="container-fluid">
     <header>
@@ -59,6 +59,10 @@
     <div class="row">
         <div class="col-md-4 col-sm-12">
             <div class="overall-description">
+                <dl>
+                    <dt><spring:message code="label.name" text="Name"/></dt>
+                    <dd><c:out value="${event.person.presentationName}"/></dd>
+                </dl>
                 <dl>
                     <dt><spring:message code="accounting.event.details.amount.pay" text="To pay"/></dt>
                     <dd><c:out value="${totalAmount}"/><span>€</span></dd>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/accounting/event-details.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/accounting/event-details.jsp
@@ -66,6 +66,10 @@
             <div class="col-md-4">
                 <div class="overall-description">
                     <dl>
+                        <dt><spring:message code="label.name" text="Name"/></dt>
+                        <dd><c:out value="${event.person.presentationName}"/></dd>
+                    </dl>
+                    <dl>
                         <dt><spring:message code="accounting.event.details.creation.date" text="Creation Date"/></dt>
                         <dd><time datetime="${event.whenOccured.toString("yyyy-MM-dd")}">${event.whenOccured.toString("dd/MM/yyyy")}</time></dd>
                     </dl>
@@ -133,7 +137,7 @@
                             <c:when test="${!debt.open}">
                                 <c:set var="cardClass" value="fully-paid"/>
                             </c:when>
-                            <c:when test="${debt.isAfterDueDate(currentDate) && !(debt.isToExemptInterest() || debt.isToExemptFine())}">
+                            <c:when test="${debt.totalOpenPenaltyAmount > 0 && debt.isAfterDueDate(currentDate) && !(debt.isToExemptInterest() || debt.isToExemptFine())}">
                                 <c:set var="cardClass" value="passed-limit"/>
                             </c:when>
                             <c:otherwise>
@@ -152,7 +156,7 @@
                                     <c:when test="${!debt.open}">
                                         <spring:message code="accounting.event.details.debt.paid" text="Paid"/>
                                     </c:when>
-                                    <c:when test="${debt.isAfterDueDate(currentDate) && !(debt.isToExemptInterest() || debt.isToExemptFine())}">
+                                    <c:when test="${debt.totalOpenPenaltyAmount > 0 && debt.isAfterDueDate(currentDate) && !(debt.isToExemptInterest() || debt.isToExemptFine())}">
                                         <spring:message code="accounting.event.details.debt.due.with.interest" text="Due with interest"/>
                                     </c:when>
                                     <c:otherwise>
@@ -186,7 +190,7 @@
                                 <dd><c:out value="${debt.date.toString('dd/MM/yyyy')}"/></dd>
                             </dl>
                             <footer>
-                                <a class="btn btn-default btn-block" href="debt/${debt.date.toString('dd-MM-yyyy')}/details">Ver Detalhes</a>
+                                <a class="btn btn-default btn-block" href="debt/${debt.date.toString('yyyy-MM-dd')}/details">Ver Detalhes</a>
                             </footer>
                         </article>
                     </c:forEach>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/accounting/events-multiple-payments-confirm.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/accounting/events-multiple-payments-confirm.jsp
@@ -92,6 +92,10 @@
                             <dt><spring:message code="label.document.id" text="ID Document"/></dt>
                             <dd><c:out value="${person.documentIdNumber}"/></dd>
                         </dl>
+                        <dl>
+                            <dt><spring:message code="label.document.vatNumber" text="VAT Number"/></dt>
+                            <dd><c:out value="${person.socialSecurityNumber}"/></dd>
+                        </dl>
                     </div>
                 </div>
             </div>
@@ -134,14 +138,21 @@
                                 <th>Valor a pagar</th>
                             </tr>
                             </thead>
-                            <tbody>
-                            <c:forEach items="${paymentsManagementDTO.selectedEntries}" var="entryDTO" varStatus="status">
+                            <c:forEach items="${eventEntryDTOMap}" var="eventKey">
+                                <tbody>
                                 <tr>
-                                    <td><c:out value="${entryDTO.description}"/></td>
-                                    <td><c:out value="${entryDTO.amountToPay}"/><span>€</span></td>
+                                    <th colspan="3">
+                                        <c:out value="${eventKey.key.description}"/>
+                                    </th>
                                 </tr>
+                                <c:forEach items="${eventKey.value}" var="entryDTO" varStatus="status">
+                                    <tr>
+                                        <td><c:out value="${entryDTO.description}"/></td>
+                                        <td><c:out value="${entryDTO.amountToPay}"/><span>€</span></td>
+                                    </tr>
+                                </c:forEach>
+                                </tbody>
                             </c:forEach>
-                            </tbody>
                         </table>
                     </section>
                 </div>

--- a/src/main/webapp/WEB-INF/fenixedu-academic/accounting/events.jsp
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/accounting/events.jsp
@@ -51,6 +51,10 @@
                             <dt><spring:message code="label.document.id" text="ID Document"/></dt>
                             <dd><c:out value="${person.documentIdNumber}"/></dd>
                         </dl>
+                        <dl>
+                            <dt><spring:message code="label.document.vatNumber" text="VAT Number"/></dt>
+                            <dd><c:out value="${person.socialSecurityNumber}"/></dd>
+                        </dl>
                     </div>
                 </div>
             </div>

--- a/src/main/webapp/WEB-INF/resources/ApplicationResources.properties
+++ b/src/main/webapp/WEB-INF/resources/ApplicationResources.properties
@@ -143,3 +143,5 @@ label.interestRate.value=Valor
 label.interestRate.log.datetime=Data e Hora
 label.interestRate.log.description=Descri\u00E7\u00E3o
 label.interestRate.log.person=Utilizador
+label.document.id=ID Document
+label.document.vatNumber=Tax Identification Number

--- a/src/main/webapp/WEB-INF/resources/ApplicationResources_en.properties
+++ b/src/main/webapp/WEB-INF/resources/ApplicationResources_en.properties
@@ -345,3 +345,5 @@ payment.reference.information=Reference Information
 label.payment.reference=Payment Reference
 payment.reference.reusable.information=This reference can be reused for all payments in the context of this debt.\nThe user should check the amount to pay and corresponding deadline according to the payment plan.
 payment.reference.for.interests.information=This payment reference should be used only once to liquidate the selected debt and interest.\nThe payment using this reference should be done within {0} days.\nAfter this deadline interest will accumulate regarding this debt.
+label.document.id=ID Document
+label.document.vatNumber=Tax Identification Number

--- a/src/main/webapp/WEB-INF/resources/ApplicationResources_pt.properties
+++ b/src/main/webapp/WEB-INF/resources/ApplicationResources_pt.properties
@@ -346,3 +346,5 @@ payment.reference.card.reference=Referencia:
 payment.reference.card.entity=Entidade:
 payment.reference.card.amount=Valor:
 accounting.event.action.pay.debts=Pagar Dívidas
+label.document.id=Num. Documento
+label.document.vatNumber=NIF


### PR DESCRIPTION
- Fixed **bug** caused by disabled checkboxes data not being passed to server
- Changed GratuityEvent description getters to be more consistent

## Please review (at least) these points before merging
1. Changes to GratuityEvent getDescriptionForEntryType to be consistent with getDescription
~~2. Removal of "select all checkboxes" feature in multiple payments interface~~
~~3. Should a TreeMap be used instead of HashMap to make event ordering consistent every time on the multiple payments interface?~~