### PR TITLE
InsurancePR: Add number of days to due date ACDM-1506 #resolve

### DIFF
--- a/src/main/dml/fenixedu-academic.dml
+++ b/src/main/dml/fenixedu-academic.dml
@@ -1348,6 +1348,7 @@ valueType org.fenixedu.academic.util.sibs.incomming.SibsIncommingPaymentFileDeta
                 }
 
             class accounting.events.insurance.InsuranceEvent extends accounting.events.AnnualEvent {
+                DateTime dueDate;
             }
 
         class accounting.events.EnrolmentEvent extends accounting.AcademicEvent {
@@ -1690,6 +1691,7 @@ valueType org.fenixedu.academic.util.sibs.incomming.SibsIncommingPaymentFileDeta
     }
 
         class accounting.postingRules.AdministrativeOfficeFeeAndInsurancePR extends accounting.PostingRule {
+
         }
 
         class accounting.postingRules.GenericSingleEntryTypePR extends accounting.PostingRule {
@@ -1805,6 +1807,7 @@ valueType org.fenixedu.academic.util.sibs.incomming.SibsIncommingPaymentFileDeta
 				}
 
 				class accounting.postingRules.InsurancePR extends accounting.postingRules.FixedAmountPR {
+				    Integer numberOfDaysToCalculateDueDate;
 				}
 				
 				class accounting.postingRules.PartialRegistrationRegimeRequestPR extends accounting.postingRules.FixedAmountPR {

--- a/src/main/java/org/fenixedu/academic/domain/accounting/events/insurance/InsuranceEvent.java
+++ b/src/main/java/org/fenixedu/academic/domain/accounting/events/insurance/InsuranceEvent.java
@@ -19,6 +19,7 @@
 package org.fenixedu.academic.domain.accounting.events.insurance;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 import org.fenixedu.academic.domain.ExecutionYear;
@@ -31,6 +32,8 @@ import org.fenixedu.academic.domain.accounting.Event;
 import org.fenixedu.academic.domain.accounting.EventType;
 import org.fenixedu.academic.domain.accounting.Exemption;
 import org.fenixedu.academic.domain.accounting.PaymentCode;
+import org.fenixedu.academic.domain.accounting.PostingRule;
+import org.fenixedu.academic.domain.accounting.postingRules.InsurancePR;
 import org.fenixedu.academic.domain.accounting.serviceAgreementTemplates.UnitServiceAgreementTemplate;
 import org.fenixedu.academic.domain.exceptions.DomainException;
 import org.fenixedu.academic.domain.organizationalStructure.Party;
@@ -42,6 +45,7 @@ import org.fenixedu.academic.util.LabelFormatter;
 import org.fenixedu.academic.util.Money;
 import org.fenixedu.bennu.core.domain.Bennu;
 import org.fenixedu.bennu.core.domain.User;
+import org.joda.time.DateTime;
 import org.joda.time.YearMonthDay;
 
 import pt.ist.fenixframework.dml.runtime.RelationAdapter;
@@ -74,6 +78,14 @@ public class InsuranceEvent extends InsuranceEvent_Base implements IInsuranceEve
     public InsuranceEvent(Person person, ExecutionYear executionYear) {
         this();
         init(EventType.INSURANCE, person, executionYear);
+        setupDueDate();
+    }
+
+    private void setupDueDate() {
+        final PostingRule postingRule = getPostingRule();
+        if (postingRule instanceof InsurancePR) {
+            setDueDate(getWhenOccured().plusDays(((InsurancePR) postingRule).getNumberOfDaysToCalculateDueDate()));
+        }
     }
 
     @Override
@@ -150,5 +162,10 @@ public class InsuranceEvent extends InsuranceEvent_Base implements IInsuranceEve
     @Override
     public boolean isInsuranceEvent() {
         return true;
+    }
+
+    @Override
+    public DateTime getDueDateByPaymentCodes() {
+        return Optional.ofNullable(getDueDate()).orElseGet(super::getDueDateByPaymentCodes);
     }
 }

--- a/src/main/java/org/fenixedu/academic/domain/accounting/postingRules/InsurancePR.java
+++ b/src/main/java/org/fenixedu/academic/domain/accounting/postingRules/InsurancePR.java
@@ -32,9 +32,11 @@ public class InsurancePR extends InsurancePR_Base implements IAdministrativeOffi
         super();
     }
 
-    public InsurancePR(DateTime startDate, DateTime endDate, ServiceAgreementTemplate serviceAgreementTemplate, Money fixedAmount) {
+    public InsurancePR(DateTime startDate, DateTime endDate, ServiceAgreementTemplate serviceAgreementTemplate, Money
+            fixedAmount, int numberOfDaysToCalculateDueDate) {
         this();
         init(EntryType.INSURANCE_FEE, EventType.INSURANCE, startDate, endDate, serviceAgreementTemplate, fixedAmount);
+        setNumberOfDaysToCalculateDueDate(numberOfDaysToCalculateDueDate);
     }
 
     @Override
@@ -42,10 +44,9 @@ public class InsurancePR extends InsurancePR_Base implements IAdministrativeOffi
         return getFixedAmount();
     }
 
-    @Override
-    public FixedAmountPR edit(final Money fixedAmount) {
+    public FixedAmountPR edit(final Money fixedAmount, Integer numberOfDaysToCalculateDueDate) {
         deactivate();
-        return new InsurancePR(new DateTime().minus(1000), null, getServiceAgreementTemplate(), fixedAmount);
+        return new InsurancePR(new DateTime().minus(1000), null, getServiceAgreementTemplate(), fixedAmount, numberOfDaysToCalculateDueDate);
     }
 
     @Override

--- a/src/main/resources/resources/ApplicationResources_en.properties
+++ b/src/main/resources/resources/ApplicationResources_en.properties
@@ -3370,6 +3370,7 @@ label.org.fenixedu.academic.domain.accounting.postingRules.BaseAmountPlusAmountP
 label.org.fenixedu.academic.domain.accounting.postingRules.EnrolmentOutOfPeriodPR.amountPerDay = Price per Day Delay (euro)
 label.org.fenixedu.academic.domain.accounting.postingRules.EnrolmentOutOfPeriodPR.baseAmount = Base Price (euro)
 label.org.fenixedu.academic.domain.accounting.postingRules.EnrolmentOutOfPeriodPR.maxAmount = Maximum Price (euro)
+label.org.fenixedu.academic.domain.accounting.postingRules.InsurancePR.numberOfDaysToCalculateDueDate = Number of days to calculate due date
 label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountPR.fixedAmount = Price (euro)
 label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountWithPenaltyFromDatePR.whenToApplyFixedAmountPenalty = Fines apply from
 label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountWithPenaltyPR.fixedAmountPenalty = Fine Price (euro)

--- a/src/main/resources/resources/ApplicationResources_pt.properties
+++ b/src/main/resources/resources/ApplicationResources_pt.properties
@@ -3378,6 +3378,7 @@ label.org.fenixedu.academic.domain.accounting.postingRules.BaseAmountPlusAmountP
 label.org.fenixedu.academic.domain.accounting.postingRules.EnrolmentOutOfPeriodPR.amountPerDay = Pre\u00E7o p/ Dia de Atraso (&euro;)
 label.org.fenixedu.academic.domain.accounting.postingRules.EnrolmentOutOfPeriodPR.baseAmount = Pre\u00E7o Base (&euro;)
 label.org.fenixedu.academic.domain.accounting.postingRules.EnrolmentOutOfPeriodPR.maxAmount = Pre\u00E7o M\u00E1ximo (&euro;)
+label.org.fenixedu.academic.domain.accounting.postingRules.InsurancePR.numberOfDaysToCalculateDueDate = Número de dias para cálculo da data limite de pagamento
 label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountPR.fixedAmount = Pre\u00E7o (&euro;)
 label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountWithPenaltyFromDatePR.whenToApplyFixedAmountPenalty = Multa aplic\u00E1vel a partir de
 label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountWithPenaltyPR.fixedAmountPenalty = Pre\u00E7o da Multa (&euro;)

--- a/src/main/webapp/WEB-INF/fenixedu-academic/schemas/prices-schemas.xml
+++ b/src/main/webapp/WEB-INF/fenixedu-academic/schemas/prices-schemas.xml
@@ -72,6 +72,12 @@
 	<slot name="fixedAmount" key="label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountPR.fixedAmount"  />
 </schema>
 
+<schema name="InsurancePR.view"
+		type="org.fenixedu.academic.domain.accounting.postingRules.FixedAmountPR"
+		bundle="APPLICATION_RESOURCES" extends="PostingRule.view">
+<slot name="numberOfDaysToCalculateDueDate" key="label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountPR.numberOfDaysToCalculateDueDate"  />
+</schema>
+
 <schema name="DeclarationRequestPR.view"
 	type="org.fenixedu.academic.domain.accounting.postingRules.serviceRequests.DeclarationRequestPR"
 	bundle="APPLICATION_RESOURCES" extends="FixedAmountPR.view">
@@ -417,7 +423,8 @@
 	type="org.fenixedu.academic.domain.accounting.postingRules.InsurancePR"
 	bundle="APPLICATION_RESOURCES">
 	<slot name="fixedAmount" key="label.org.fenixedu.academic.domain.accounting.postingRules.FixedAmountPR.fixedAmount" />
-	<setter signature="edit(fixedAmount)"/>
+	<slot name="numberOfDaysToCalculateDueDate" key="label.org.fenixedu.academic.domain.accounting.postingRules.InsurancePR.numberOfDaysToCalculateDueDate" />
+	<setter signature="edit(fixedAmount, numberOfDaysToCalculateDueDate)"/>
 </schema>
 
 <schema name="FixedAmountWithPenaltyPR.edit"

--- a/src/main/webapp/manager/payments/postingRules/management/showInsurancePostingRules.jsp
+++ b/src/main/webapp/manager/payments/postingRules/management/showInsurancePostingRules.jsp
@@ -32,7 +32,7 @@
 
 <br />
 
-<fr:view name="postingRules" schema="FixedAmountPR.view">
+<fr:view name="postingRules" schema="InsurancePR.view">
 	<fr:layout name="tabular">
 		<fr:property name="classes" value="tstyle4 thlight thright mtop05" />
 		<fr:property name="linkFormat(edit)"


### PR DESCRIPTION
```
alter table `POSTING_RULE` add `NUMBER_OF_DAYS_TO_CALCULATE_DUE_DATE` int(11) DEFAULT NULL;
alter table `EVENT` add `DUE_DATE` datetime NULL default NULL;
update EVENT set DUE_DATE = DATE_ADD(WHEN_OCCURED, INTERVAL 60 DAY) where oid2cname(OID) = 'org.fenixedu.academic.domain.accounting.events.insurance.InsuranceEvent';
update POSTING_RULE set NUMBER_OF_DAYS_TO_CALCULATE_DUE_DATE = 60 where oid2cname(OID) = 'org.fenixedu.academic.domain.accounting.postingRules.InsurancePR';
```