### PR TITLE
Update dependencies using Versions Maven Plugin ACDM-1527 #resolve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,40 +19,40 @@
 
     <properties>
         <version.com.github.axet.kaptcha>0.0.9</version.com.github.axet.kaptcha>
-        <version.com.google.code.gson.gson>2.8.0</version.com.google.code.gson.gson>
+        <version.com.google.code.gson.gson>2.8.5</version.com.google.code.gson.gson>
         <version.com.google.guava.guava>21.0</version.com.google.guava.guava>
-        <version.com.googlecode.libphonenumber.libphonenumber>8.2.0</version.com.googlecode.libphonenumber.libphonenumber>
-        <version.com.lowagie.itext>2.0.8</version.com.lowagie.itext>
-        <version.com.sun.mail.javax.mail>1.5.6</version.com.sun.mail.javax.mail>
-        <version.com.twilio.sdk.twilio-java-sdk>7.24.2</version.com.twilio.sdk.twilio-java-sdk>
+        <version.com.googlecode.libphonenumber.libphonenumber>8.9.16</version.com.googlecode.libphonenumber.libphonenumber>
+        <version.com.lowagie.itext>2.1.7</version.com.lowagie.itext>
+        <version.com.sun.mail.javax.mail>1.6.2</version.com.sun.mail.javax.mail>
+        <version.com.twilio.sdk.twilio-java-sdk>7.29.0</version.com.twilio.sdk.twilio-java-sdk>
         <version.commons-beanutils.commons-beanutils>1.9.3</version.commons-beanutils.commons-beanutils>
         <version.commons-collections.commons-collections>3.2.2</version.commons-collections.commons-collections>
         <version.commons-httpclient.commons-httpclient>3.1</version.commons-httpclient.commons-httpclient>
-        <version.commons-io.commons-io>2.5</version.commons-io.commons-io>
+        <version.commons-io.commons-io>2.6</version.commons-io.commons-io>
         <version.commons-lang.commons-lang>2.6</version.commons-lang.commons-lang>
-        <version.commons-validator.commons-validator>1.5.1</version.commons-validator.commons-validator>
+        <version.commons-validator.commons-validator>1.6</version.commons-validator.commons-validator>
         <version.javax.faces.jsf-api>1.1_01</version.javax.faces.jsf-api>
         <version.javax.faces.jsf-impl>1.1</version.javax.faces.jsf-impl>
         <version.javax.servlet.jsp.jsp-api>2.1</version.javax.servlet.jsp.jsp-api>
         <version.javax.ws.rs.javax.ws.rs.api>2.0</version.javax.ws.rs.javax.ws.rs.api>
-        <version.joda.time.joda.time>2.9.7</version.joda.time.joda.time>
-        <version.net.sourceforge.htmlcleaner.htmlcleaner>2.18</version.net.sourceforge.htmlcleaner.htmlcleaner>
+        <version.joda.time.joda.time>2.10</version.joda.time.joda.time>
+        <version.net.sourceforge.htmlcleaner.htmlcleaner>2.22</version.net.sourceforge.htmlcleaner.htmlcleaner>
         <version.org.apache.poi.poi>3.17</version.org.apache.poi.poi>
-        <version.org.fenixedu.bennu-renderers>5.1.1</version.org.fenixedu.bennu-renderers>
+        <version.org.fenixedu.bennu-renderers>5.3.1</version.org.fenixedu.bennu-renderers>
         <version.org.fenixedu.bennu-modular-rendering>1.1.0</version.org.fenixedu.bennu-modular-rendering>
-        <version.org.fenixedu.bennu>5.0.2</version.org.fenixedu.bennu>
+        <version.org.fenixedu.bennu>5.2.1</version.org.fenixedu.bennu>
         <version.org.fenixedu.fenixedu-commons>2.0.0</version.org.fenixedu.fenixedu-commons>
-        <version.org.fenixedu.fenixedu-spaces>2.1.1</version.org.fenixedu.fenixedu-spaces>
-        <version.org.fenixedu.messaging>3.6.0</version.org.fenixedu.messaging>
+        <version.org.fenixedu.fenixedu-spaces>2.2.1</version.org.fenixedu.fenixedu-spaces>
+        <version.org.fenixedu.messaging>3.7.1</version.org.fenixedu.messaging>
         <version.org.imgscalr.imgscalr-lib>4.2</version.org.imgscalr.imgscalr-lib>
-        <version.org.jsoup.jsoup>1.7.3</version.org.jsoup.jsoup>
+        <version.org.jsoup.jsoup>1.11.3</version.org.jsoup.jsoup>
         <version.org.mnode.ical4j.ical4j>1.0.5.2</version.org.mnode.ical4j.ical4j>
         <version.org.xhtmlrenderer.core-renderer>R8</version.org.xhtmlrenderer.core-renderer>
-        <version.pt.ist.standards>1.0.3</version.pt.ist.standards>
+        <version.pt.ist.standards>1.0.4</version.pt.ist.standards>
         <version.pt.ist.tidy>1.0</version.pt.ist.tidy>
         <version.taglibs.datetime>1.0.1</version.taglibs.datetime>
         <version.taglibs.strings>1.1.0</version.taglibs.strings>
-        <version.com.fasterxml.jackson.core.jackson-databind>2.8.11</version.com.fasterxml.jackson.core.jackson-databind>
+        <version.com.fasterxml.jackson.core.jackson-databind>2.9.7</version.com.fasterxml.jackson.core.jackson-databind>
         <version.org.fenixedu.postCodeTools>1.1.2</version.org.fenixedu.postCodeTools>
         <version.org.fenixedu.tinTools>1.0.0</version.org.fenixedu.tinTools>
     </properties>
@@ -312,6 +312,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
             <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Added explicit jackson.annotation dependency since we were using twilio's transitive dependency (which broke things in testing when it mismatched with jackson.databind-core).