### PR TITLE
Upgrade to Guava 27.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <version.com.github.axet.kaptcha>0.0.9</version.com.github.axet.kaptcha>
         <version.com.google.code.gson.gson>2.8.5</version.com.google.code.gson.gson>
-        <version.com.google.guava.guava>21.0</version.com.google.guava.guava>
+        <version.com.google.guava.guava>27.0-jre</version.com.google.guava.guava>
         <version.com.googlecode.libphonenumber.libphonenumber>8.9.16</version.com.googlecode.libphonenumber.libphonenumber>
         <version.com.lowagie.itext>2.1.7</version.com.lowagie.itext>
         <version.com.sun.mail.javax.mail>1.6.2</version.com.sun.mail.javax.mail>

--- a/src/main/java/org/fenixedu/academic/domain/person/HumanName.java
+++ b/src/main/java/org/fenixedu/academic/domain/person/HumanName.java
@@ -218,7 +218,7 @@ public class HumanName {
         if (name == null) {
             return null;
         }
-        return Strings.emptyToNull(CharMatcher.WHITESPACE.trimAndCollapseFrom(name, ' '));
+        return Strings.emptyToNull(CharMatcher.whitespace().trimAndCollapseFrom(name, ' '));
     }
 
     public static String nameCapitalization(String name) {
@@ -259,26 +259,15 @@ public class HumanName {
         if (delimiters == null) {
             return Character.isWhitespace(buffer[i]);
         }
-        for (final String delimiter : delimiters) {
-            if (i - delimiter.length() + 1 < 0) {
-                continue;
-            }
-            if (delimiter.equals(String.valueOf(buffer, i - delimiter.length() + 1, delimiter.length()))) {
-                return true;
-            }
-        }
-        return false;
+        return Arrays.stream(delimiters)
+                .filter(delimiter -> i - delimiter.length() + 1 >= 0)
+                .anyMatch(delimiter -> delimiter.equals(String.valueOf(buffer, i - delimiter.length() + 1, delimiter.length())));
     }
 
     private static boolean isException(char[] buffer, int i, Multimap<Integer, String> exceptionBySize) {
-        for (Integer size : exceptionBySize.keySet()) {
-            if (i + size > buffer.length) {
-                continue;
-            }
-            if (exceptionBySize.get(size).contains(String.valueOf(buffer, i, size))) {
-                return true;
-            }
-        }
-        return false;
+        return exceptionBySize.keySet()
+                .stream()
+                .filter(size -> i + size <= buffer.length)
+                .anyMatch(size -> exceptionBySize.get(size).contains(String.valueOf(buffer, i, size)));
     }
 }


### PR DESCRIPTION
This upgrade is important mainly for the security fixes (e.g. **hash flooding protection**).

There are some method deprecations in the io.Files but no breaking removals yet.

Only breaking changes was CharMatcher that instead of providing public static constants, now provides public static factory methods.

**Release Links**
- https://github.com/google/guava/wiki/Release22
- https://github.com/google/guava/wiki/Release23
- https://github.com/google/guava/releases (23.1 to 27.0)