### PR TITLE
Add explicit jackson-core dependency to override twilio transitive version ACDM-1533 #resolve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,11 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${version.com.fasterxml.jackson.core.jackson-databind}</version>
         </dependency>


### PR DESCRIPTION
Twilio SDK provided a jackson-core dependency which was inconsistent with our recent jackson dependencies update.

`+- com.twilio.sdk:twilio:jar:7.29.0:compile
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.2:compile
[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-core:jar:2.8.11:compile
[INFO] |  |  \- javax.xml.bind:jaxb-api:jar:2.2:compile
[INFO] |  |     \- javax.xml.stream:stax-api:jar:1.0-2:compile`

