### PR TITLE
Make introductory text be visible in edit box ACDM-1628 #resolve

### DIFF
--- a/src/main/java/org/fenixedu/academic/ui/struts/action/mobility/outbound/OutboundMobilityCandidacyDA.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/mobility/outbound/OutboundMobilityCandidacyDA.java
@@ -77,6 +77,14 @@ public class OutboundMobilityCandidacyDA extends FenixDispatchAction {
         if (outboundMobilityContextBean == null) {
             outboundMobilityContextBean = new OutboundMobilityContextBean();
         }
+
+        //dirty hack to populate option description text box with current description
+        if (outboundMobilityContextBean.getOptionIntroductoryDestription() == null
+                && outboundMobilityContextBean.getCandidacyPeriods().size() == 1) {
+            outboundMobilityContextBean.setOptionIntroductoryDestription(outboundMobilityContextBean
+                    .getCandidacyPeriods().first().getOptionIntroductoryDestription());
+        }
+
         return prepare(mapping, request, outboundMobilityContextBean);
     }
 


### PR DESCRIPTION
Note: the edits are only submitted successfully when both the Option selection introductory text box and the Option text box have any input.