### PR TITLE
Add `box-sizing: content-box` to donuts in Student Statistics page ACDM-1847 #resolve

### DIFF
--- a/src/main/webapp/javaScript/sviz/sviz.css
+++ b/src/main/webapp/javaScript/sviz/sviz.css
@@ -76,7 +76,7 @@ x:-o-prefocus,.qtip .qtip-tip{visibility:hidden}
 #qtip-overlay.blurs{cursor:pointer}
 #qtip-overlay div{position:absolute;left:0;top:0;width:100%;height:100%;background-color:#000;opacity:.7;filter:alpha(opacity=70);-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=70)"}
 .qtipmodal-ie6fix{position:absolute !important}
-.donut{padding-right:10px;padding-left:10px;cursor:pointer}
+.donut{padding-right:10px;padding-left:10px;cursor:pointer;box-sizing:content-box}
 .donut-center-text{color:#000;font-weight:bold}
 .donut-not-evaluated-grades{fill:#000}
 .donut-negative-grades{fill:#f13939}
@@ -122,7 +122,7 @@ svg foreignobject body{background-color:#fff}
 .boxplot-line{stroke:#000;stroke-dasharray:5,5}
 .boxplot-quantile-line{stroke:#000}
 .bubbles-label{font-size:12px;font-weight:bold;cursor:pointer}
-.donut{padding-right:10px;padding-left:10px;cursor:pointer}
+.donut{padding-right:10px;padding-left:10px;cursor:pointer;box-sizing:content-box}
 .donut-cat1{fill:#000}
 .donut-cat2{fill:#f13939}
 .donut-cat3{fill:#66cc33}


### PR DESCRIPTION
Previously, without this CSS property, the donuts were visually cut in the UI. Now they are shown properly.

### Before

![image](https://user-images.githubusercontent.com/7467891/115629351-18692600-a2fa-11eb-9d50-ed8b4de5b6cd.png)

### After

![image](https://user-images.githubusercontent.com/7467891/115629372-21f28e00-a2fa-11eb-8f4c-e52c3808031e.png)
